### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/common/anon/RandomNumberGenerator.h
+++ b/src/common/anon/RandomNumberGenerator.h
@@ -33,7 +33,7 @@ namespace RandomNumberGenerator {
 	unsigned int generate();
 	unsigned int generate(unsigned int rangemin, unsigned int rangemax);
 
-};
+}
 
 #endif // __RANDOM_NUMBER_GENERATOR_H
 

--- a/src/common/ipfixlolib/ipfixlolib.c
+++ b/src/common/ipfixlolib/ipfixlolib.c
@@ -1599,7 +1599,7 @@ static void ipfix_prepend_header(ipfix_exporter *p_exporter, int data_length, ip
         } else {
                 // compute it on our own:
                 // sum up all lengths in the iovecs:
-                int i;
+                unsigned int i;
 
                 // start the loop with 1, as 0 is reserved for the header!
                 for (i = 1; i< sendbuf->current;  i++) {
@@ -2332,7 +2332,9 @@ static int ipfix_send_templates(ipfix_exporter* exporter)
 							msg(MSG_VDEBUG, "%d template bytes sent to SCTP collector %s:%d",
 								bytes_sent, col->ipv4address, col->port_number);
 						}
-					} else DPRINTF("No Template to send to SCTP collector");
+					} else {
+					    DPRINTF("No Template to send to SCTP collector");
+					}
 					break;	
 				default:
 				msg(MSG_FATAL, "Unknown collector socket state");
@@ -2847,7 +2849,7 @@ int ipfix_cancel_data_set(ipfix_exporter *exporter)
 {
 	ipfix_set_manager *manager = &(exporter->data_sendbuffer->set_manager);
 	unsigned current = manager->set_counter;
-	int i;
+	unsigned int i;
 
 	// security check
 	if(exporter->data_sendbuffer->current == exporter->data_sendbuffer->committed) {

--- a/src/common/ipfixlolib/ipfixlolib.c
+++ b/src/common/ipfixlolib/ipfixlolib.c
@@ -1175,7 +1175,7 @@ static int add_collector_dtls(
 
     // we need aux_config for setting up a DTLS collector
     if (!aux_config) {
-        return -1
+        return -1;
     }
 
     ipfix_aux_config_dtls *aux_config_dtls;

--- a/src/common/ipfixlolib/ipfixlolib.c
+++ b/src/common/ipfixlolib/ipfixlolib.c
@@ -2270,7 +2270,7 @@ static int ipfix_send_templates(ipfix_exporter* exporter)
 							    col->port_number);
 						} else {
 						    msg(MSG_ERROR,
-							    "could not send to %s:%d errno: %s  (UDP)",
+							    "could not send templates to %s:%d errno: %s  (UDP)",
 							    col->ipv4address,
 							    col->port_number,
 							    strerror(errno));
@@ -2319,7 +2319,7 @@ static int ipfix_send_templates(ipfix_exporter* exporter)
 							0 // context
 							)) == -1) {
 							// send failed
-							msg(MSG_ERROR, "could not send to %s:%d errno: %s  (SCTP)",col->ipv4address, col->port_number, strerror(errno));
+							msg(MSG_ERROR, "could not send templates to %s:%d errno: %s  (SCTP)",col->ipv4address, col->port_number, strerror(errno));
 							sctp_reconnect(exporter, i); //1st reconnect attempt 
 							// if result is C_DISCONNECTED and sctp_reconnect_timer == 0, collector will 
 							// be removed on the next call of ipfix_send_templates()
@@ -2454,7 +2454,7 @@ static int ipfix_send_data(ipfix_exporter* exporter)
 						exporter->data_sendbuffer->entries,
 						exporter->data_sendbuffer->committed
 							     )) == -1){
-						msg(MSG_ERROR, "could not send to %s:%d errno: %s  (UDP)",col->ipv4address, col->port_number, strerror(errno));
+						msg(MSG_ERROR, "could not send data to %s:%d errno: %s  (UDP)",col->ipv4address, col->port_number, strerror(errno));
 						if (errno == EMSGSIZE) {
 						    msg(MSG_ERROR, "Updating MTU estimate for collector %s:%d",
 							    col->ipv4address,
@@ -2478,7 +2478,7 @@ static int ipfix_send_data(ipfix_exporter* exporter)
 						exporter->data_sendbuffer->committed,
 						exporter->sctp_lifetime
 							     )) == -1){
-						msg(MSG_VDEBUG, "could not send to %s:%d (DTLS over SCTP)",col->ipv4address, col->port_number);
+						msg(MSG_VDEBUG, "could not send data to %s:%d (DTLS over SCTP)",col->ipv4address, col->port_number);
 					}else{
 
 						msg(MSG_VDEBUG, "%d data bytes sent to DTLS over SCTP collector %s:%d",
@@ -2500,7 +2500,7 @@ static int ipfix_send_data(ipfix_exporter* exporter)
 						0 // context
 						)) == -1) {
 						// send failed
-						msg(MSG_ERROR, "could not send to %s:%d errno: %s  (SCTP)",col->ipv4address, col->port_number, strerror(errno));
+						msg(MSG_ERROR, "could not send data to %s:%d errno: %s  (SCTP)",col->ipv4address, col->port_number, strerror(errno));
 						// drop data and call sctp_reconnect
 						sctp_reconnect(exporter, i);
 						// if result is C_DISCONNECTED and sctp_reconnect_timer == 0, collector will 
@@ -2516,7 +2516,7 @@ static int ipfix_send_data(ipfix_exporter* exporter)
 						exporter->data_sendbuffer->entries,
 						exporter->data_sendbuffer->committed
 							     )) == -1){
-						msg(MSG_VDEBUG, "could not send to %s:%d (DTLS over UDP)",col->ipv4address, col->port_number);
+						msg(MSG_VDEBUG, "could not send data to %s:%d (DTLS over UDP)",col->ipv4address, col->port_number);
 					}else{
 
 						msg(MSG_VDEBUG, "%d data bytes sent to DTLS over UDP collector %s:%d",

--- a/src/common/ipfixlolib/ipfixlolib.h
+++ b/src/common/ipfixlolib/ipfixlolib.h
@@ -492,7 +492,7 @@ typedef struct {
  */
 typedef struct {
 	char ipv4address[16];
-	uint32_t port_number;
+	uint16_t port_number;
 	enum ipfix_transport_protocol protocol;
 	int data_socket; // socket data and templates are sent to
 	/* data_socket is NOT used for DTLS connections */
@@ -613,8 +613,8 @@ int ipfix_beat(ipfix_exporter *exporter);
 int ipfix_init_exporter(uint32_t observation_domain_id, ipfix_exporter **exporter);
 int ipfix_deinit_exporter(ipfix_exporter *exporter);
 
-int ipfix_add_collector(ipfix_exporter *exporter, const char *coll_ip4_addr, int coll_port, enum ipfix_transport_protocol proto, void *aux_config);
-int ipfix_remove_collector(ipfix_exporter *exporter, const char *coll_ip4_addr, int coll_port);
+int ipfix_add_collector(ipfix_exporter *exporter, const char *coll_ip4_addr, uint16_t coll_port, enum ipfix_transport_protocol proto, void *aux_config);
+int ipfix_remove_collector(ipfix_exporter *exporter, const char *coll_ip4_addr, uint16_t coll_port);
 int ipfix_start_template(ipfix_exporter *exporter, uint16_t template_id,  uint16_t field_count);
 int ipfix_start_optionstemplate_set(ipfix_exporter *exporter, uint16_t template_id, uint16_t scope_length, uint16_t option_length);
 int ipfix_start_datatemplate(ipfix_exporter *exporter, uint16_t template_id, uint16_t preceding, uint16_t field_count, uint16_t fixedfield_count);

--- a/src/common/msg.h
+++ b/src/common/msg.h
@@ -65,14 +65,14 @@ void vermont_exception(const int, const char*, const char*, const char*, const c
 //#endif
 
 // useful defines for logging
-#define THROWEXCEPTION(fmt, args...) vermont_exception(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, fmt, ##args)
+#define THROWEXCEPTION(...) vermont_exception(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, ##__VA_ARGS__)
 
-#define msg(lvl, fmt, args...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, lvl, fmt, ##args)
+#define msg(...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, ##__VA_ARGS__)
 
 #ifdef DEBUG
 
-#define DPRINTF(fmt, args...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, MSG_DEBUG, fmt, ##args)
-#define DPRINTFL(lvl, fmt, args...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, lvl, fmt, ##args)
+#define DPRINTF(...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, MSG_DEBUG, ##__VA_ARGS__)
+#define DPRINTFL(...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, ##__VA_ARGS__)
 
 #define ASSERT(exp, description)                                                                        \
     {                                                                                                   \
@@ -84,8 +84,8 @@ void vermont_exception(const int, const char*, const char*, const char*, const c
 
 #else
 
-#define DPRINTF(fmt, args...)
-#define DPRINTFL(lvl, fmt, args...)
+#define DPRINTF(...)
+#define DPRINTFL(...)
 #define ASSERT(exp, description)
 
 #endif

--- a/src/core/Module.cpp
+++ b/src/core/Module.cpp
@@ -7,7 +7,7 @@
 Module::Module() 
 	: exitFlag(false), running(false)
 { 
-};
+}
 
 
 Module::~Module()

--- a/src/core/XMLAttribute.h
+++ b/src/core/XMLAttribute.h
@@ -24,7 +24,7 @@ protected:
 		return reinterpret_cast<xmlAttrPtr>(XMLNode::cobj());
 	}
 
-	inline const xmlAttrPtr cobj() const
+	inline xmlAttrPtr cobj() const
 	{
 		return reinterpret_cast<const xmlAttrPtr>(XMLNode::cobj());
 	}

--- a/src/core/XMLNode.h
+++ b/src/core/XMLNode.h
@@ -84,7 +84,7 @@ protected:
 		return xmlNode;
 	}
 
-	inline const xmlNodePtr cobj() const {
+	inline xmlNodePtr cobj() const {
 		return xmlNode;
 	}
 

--- a/src/modules/ipfix/IpfixCsExporter.hpp
+++ b/src/modules/ipfix/IpfixCsExporter.hpp
@@ -97,7 +97,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 
 		struct CS_Ipfix_file_header {
 			uint8_t magic[8]; //expected: CS_IPFIX_MAGIC
-		} DISABLE_ALIGNMENT;
+		} DISABLE_ALIGNMENT
 
 		/**
 		 * class representing the start of a chunk in the CS format
@@ -106,7 +106,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 			uint16_t ipfix_type; //-> CS_IPFIX_CHUNK_TYPE -> 0x0008
 			uint32_t chunk_length; //number of bytes in chunk starting after this element, this should be flow_count*sizeof(Ipfix_basic_flow)+4
 			uint32_t flow_count; //number of Ipfix_basic_flow records to follow
-		} DISABLE_ALIGNMENT;
+		} DISABLE_ALIGNMENT
 
 		struct Ipfix_basic_flow {
 			uint16_t record_length;                 // total length of this record minus length of this element
@@ -129,7 +129,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 			uint64_t rev_octet_total_count;
 			uint64_t rev_packet_total_count;
 			uint8_t  rev_tcp_control_bits;
-		} DISABLE_ALIGNMENT;
+		} DISABLE_ALIGNMENT
 
 		list<Ipfix_basic_flow*> chunkList;
 		uint32_t chunkListSize;

--- a/src/modules/ipfix/IpfixReceiverDtlsUdpIpV4.hpp
+++ b/src/modules/ipfix/IpfixReceiverDtlsUdpIpV4.hpp
@@ -62,7 +62,7 @@ class IpfixReceiverDtlsUdpIpV4 : public IpfixReceiver, Sensor {
 	IpfixReceiverDtlsUdpIpV4(int port, const std::string ipAddr = "",
 	    const std::string &certificateChainFile = "", const std::string &privateKeyFile = "",
 	    const std::string &caFile = "", const std::string &caPath = "",
-	    const std::set<string> &peerFqdns = std::set<string>(), const uint32_t buffer);
+	    const std::set<string> &peerFqdns = std::set<string>(), const uint32_t buffer = 0);
 	virtual ~IpfixReceiverDtlsUdpIpV4();
 
 	virtual void run();

--- a/src/modules/ipfix/IpfixReceiverFile.cpp
+++ b/src/modules/ipfix/IpfixReceiverFile.cpp
@@ -196,11 +196,13 @@ void IpfixReceiverFile::run()
 			/*reset the filepointer to the begin of the message*/
 			packetFile.seekg(-(int)(sizeof(uint32_t)), std::ios::cur); 
 
+			/** @todo uint_16 can never be > 65536
 			if (n > MAX_MSG_LEN) {
 				msg(MSG_ERROR, "IpfixReceiverFile: packet at idx=%u too big with n=%u in file \"%s\"", 
 						idx, n, packet_file_path.c_str());
 				continue;
 			}
+*/
 
 			data.reset(new uint8_t[MAX_MSG_LEN]);
 			packetFile.read(reinterpret_cast<char*>(data.get()), n);

--- a/src/modules/ipfix/IpfixRecord.cpp
+++ b/src/modules/ipfix/IpfixRecord.cpp
@@ -80,7 +80,7 @@ namespace InformationElement {
 	/**
 	 * @returns valid protocols for given field, binary ORed if multiple protocols are possible
 	 */
-	const Packet::IPProtocolType IeInfo::getValidProtocols()
+	Packet::IPProtocolType IeInfo::getValidProtocols()
 	{
 		if (enterprise==0 || enterprise==IPFIX_PEN_reverse) {
 			switch (id) {

--- a/src/modules/ipfix/IpfixRecord.hpp
+++ b/src/modules/ipfix/IpfixRecord.hpp
@@ -82,7 +82,7 @@ namespace InformationElement {
 
 		bool isReverseField() const;
 		IeInfo getReverseDirection();
-		const Packet::IPProtocolType getValidProtocols();
+		Packet::IPProtocolType getValidProtocols();
 		string toString() const;
 		bool existsReverseDirection();
 	};

--- a/src/modules/ipfix/aggregator/BaseHashtable.cpp
+++ b/src/modules/ipfix/aggregator/BaseHashtable.cpp
@@ -315,10 +315,11 @@ void BaseHashtable::expireFlows(bool all)
 			// problem here: flows with active timeout may be exported passive timeout seconds too late
 			// now must be updated by the child classes
 			if ((bucket->expireTime < now) || (bucket->forceExpireTime < now) || all) {
-				if (now > bucket->forceExpireTime)
+				if (now > bucket->forceExpireTime) {
 					DPRINTF("expireFlows: forced expiry");
-				else if (now > bucket->expireTime)
+				} else if (now > bucket->expireTime) {
 					DPRINTF("expireFlows: normal expiry");
+				}
 				if (bucket->inTable) removeBucket(bucket);
 				statExportedBuckets++;
 				exportBucket(bucket);

--- a/src/modules/packet/Observer.cpp
+++ b/src/modules/packet/Observer.cpp
@@ -105,7 +105,7 @@ Observer::Observer(const std::string& interface, bool offline, uint64_t maxpacke
 				"adjust compile-time parameter PCAP_MAX_CAPTURE_LENGTH!", capturelen, PCAP_DEFAULT_CAPTURE_LENGTH);
 
 	}
-};
+}
 
 Observer::~Observer()
 {
@@ -475,7 +475,7 @@ void Observer::performStart()
 
 	msg(MSG_DEBUG, "now starting capturing thread");
 	thread.run(this);
-};
+}
 
 void Observer::performShutdown()
 {

--- a/src/modules/packet/PSAMPExporterModule.cpp
+++ b/src/modules/packet/PSAMPExporterModule.cpp
@@ -66,7 +66,7 @@ PSAMPExporterModule::~PSAMPExporterModule()
         for (int i = 0; i < numPacketsToRelease; i++) {
 		(packetsToRelease[i])->removeReference();
 	}
-};
+}
 
 
 void PSAMPExporterModule::startNewPacketStream()

--- a/src/modules/packet/filter/RandomSampler.cpp
+++ b/src/modules/packet/filter/RandomSampler.cpp
@@ -68,7 +68,7 @@ RandomSampler::RandomSampler(int n, int N) : samplingSize(N), acceptSize(n), cur
 
                 sampleMask[pos] = true;
         }
-};
+}
 
 bool RandomSampler::processPacket(Packet *p)
 {

--- a/src/modules/packet/filter/RegExFilter.cpp
+++ b/src/modules/packet/filter/RegExFilter.cpp
@@ -31,7 +31,7 @@ inline bool RegExFilter::compare(char *pdata)
 
 	return false;
 
-};
+}
 
 bool RegExFilter::processPacket(Packet* p)
 {
@@ -49,4 +49,4 @@ bool RegExFilter::processPacket(Packet* p)
 
 	return result;
 
-};
+}

--- a/src/modules/packet/filter/StringFilter.cpp
+++ b/src/modules/packet/filter/StringFilter.cpp
@@ -97,7 +97,7 @@ inline bool StringFilter::compare(unsigned char *pdata, std::string toMatch, uns
     }
     return false;
 
-};
+}
 
 /**
  * prepare the Packet for comparefucntion
@@ -128,4 +128,4 @@ bool StringFilter::processPacket(Packet *p)
 	    return false;
 
     return true;
-};
+}

--- a/src/tests/ipfixlolib/test_everything.cc
+++ b/src/tests/ipfixlolib/test_everything.cc
@@ -20,7 +20,9 @@ int print_usage(void){
 	
 	printf("How To Use Tests:\n\n");
 	printf("\t--- Just what you are reading: \th \n");
+#ifdef SUPPORT_SCTP
 	printf("\t--- Create SCTP collector: \tc \n");
+#endif
 	printf("\t--- Create UDP collector: \tu \n");
 	printf("\t--- Template creation: \t\tt \n");
 	printf("\t--- Template creation with custom ID: \tT 777 \n");
@@ -134,7 +136,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'd':
 			//delete template
-			assert(scanf("%d",&delete_id)==1);
+			assert(scanf("%u",&delete_id)==1);
 			printf("Start testing Template destruction ID : %d!\n", delete_id);
 			
 			ret=ipfix_remove_template(my_exporter, delete_id);
@@ -189,6 +191,8 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "ipfix_remove_collector failed!\n");
 		exit(-1);
 	}
+*/
+#ifdef SUPPORT_SCTP
 	if(sctp_exists){
 		
 		printf("Remove  SCTP Collector!\n");
@@ -198,7 +202,7 @@ int main(int argc, char *argv[])
 			exit(-1);
 		}
 	}
-*/	
+#endif
 	printf("deinit exporter!\n");
 	
 	ipfix_deinit_exporter(my_exporter);

--- a/src/tests/vermonttest/TestSuiteBase.h
+++ b/src/tests/vermonttest/TestSuiteBase.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 
-#define ERROR(fmt, args...) vermont_exception(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, fmt, ##args)
+#define ERROR(...) vermont_exception(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, ##__VA_ARGS__)
 
 // redefine assert, so that ASSERT is always properly defined in unit tests
 #undef ASSERT


### PR DESCRIPTION
This fixes some of the warnings reported when compiling with:
```bash
CFLAGS="-std=gnu11 -Wall -Wextra -pedantic" CXXFLAGS="-std=gnu++11 -Wall -Wextra -pedantic" cmake ../vermont
```
The goal is fix them all so that it can be compiled with:
```bash
CFLAGS="-std=gnu11 -Werror -Wall -Wextra -pedantic" CXXFLAGS="-std=gnu++11 -Werror -Wall -Wextra -pedantic" cmake ../vermont
```