### PR TITLE
Fix getValidProtocols exception if flow has protocolId

### DIFF
--- a/src/modules/ipfix/IpfixRecord.cpp
+++ b/src/modules/ipfix/IpfixRecord.cpp
@@ -151,7 +151,7 @@ namespace InformationElement {
 				}
 			}
 		}
-		THROWEXCEPTION("received unknown field type %s", toString().c_str());
+		DPRINTF("received unknown field type %s", toString().c_str());
 		return Packet::NONE;
 	}
 


### PR DESCRIPTION
If a template has a field that is not recognised by
IeInfo::getValidProtocols an exception will be thrown causing
Vermont to abort, even though there is an explicit exception
when the protocolId is part of the template.
Fix it by parsing all the fields first, and only then raise
an exception is no valid protocol is found.

Signed-off-by: Luca Boccassi <lboccass@brocade.com>