### PR TITLE
Support 16 bits tcpControlFlags in the Ipfix Aggregator

### DIFF
--- a/src/modules/ipfix/Connection.cpp
+++ b/src/modules/ipfix/Connection.cpp
@@ -158,9 +158,33 @@ Connection::Connection(IpfixDataRecord* record)
 	fi = record->templateInfo->getFieldInfo(IPFIX_TYPEID_packetDeltaCount, IPFIX_PEN_reverse);
 	if (fi != 0) dstPackets = *(uint64_t*)(record->data + fi->offset);
 	fi = record->templateInfo->getFieldInfo(IPFIX_TYPEID_tcpControlBits, 0);
-	if (fi != 0) srcTcpControlBits = *(uint8_t*)(record->data + fi->offset);
+	if (fi != 0) {
+		/*
+		 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+		 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+		 */
+		if (fi->type.length == 2) {
+			srcTcpControlBits = *(uint16_t*)(record->data + fi->offset);
+		} else if (fi->type.length == 1) {
+			srcTcpControlBits = htons((uint16_t)*(uint8_t*)(record->data + fi->offset));
+		} else {
+			srcTcpControlBits = 0;
+		}
+	}
 	fi = record->templateInfo->getFieldInfo(IPFIX_TYPEID_tcpControlBits, IPFIX_PEN_reverse);
-	if (fi != 0) dstTcpControlBits = *(uint8_t*)(record->data + fi->offset);
+	if (fi != 0) {
+		/*
+		 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+		 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+		 */
+		if (fi->type.length == 2) {
+			dstTcpControlBits = *(uint16_t*)(record->data + fi->offset);
+		} else if (fi->type.length == 1) {
+			dstTcpControlBits = htons((uint16_t)*(uint8_t*)(record->data + fi->offset));
+		} else {
+			dstTcpControlBits = 0;
+		}
+	}
 	fi = record->templateInfo->getFieldInfo(IPFIX_ETYPEID_frontPayload, IPFIX_PEN_vermont);
 	if (fi != 0 && fi->type.length) {
 		TemplateInfo::FieldInfo* filen = record->templateInfo->getFieldInfo(IPFIX_ETYPEID_frontPayloadLen, IPFIX_PEN_vermont);
@@ -233,12 +257,13 @@ bool Connection::swapIfNeeded()
 	return false;
 }
 
-string Connection::printTcpControlBits(uint8_t bits)
+string Connection::printTcpControlBits(uint16_t bits)
 {
 	ostringstream oss;
-	const string strbits[] = { "", "", "URG", "ACK", "PSH", "RST", "SYN", "FIN" };
-	for (int i=0; i<8; i++) {
-		if ((bits&0x80)>0) oss << strbits[i];
+	const string strbits[] = { "", "", "", "", "", "", "", "NS",
+			"CWR", "ECE", "URG", "ACK", "PSH", "RST", "SYN", "FIN" };
+	for (int i=0; i<16; i++) {
+		if ((bits&0x100)>0) oss << strbits[i];
 		bits <<= 1;
 	}
 	return oss.str();

--- a/src/modules/ipfix/Connection.h
+++ b/src/modules/ipfix/Connection.h
@@ -33,10 +33,16 @@ using namespace std;
 class Connection
 {
 	public:
-		static const uint8_t FIN = 0x01;
-		static const uint8_t SYN = 0x02;
-		static const uint8_t RST = 0x04;
-		static const uint8_t ACK = 0x10;
+		// static values in network order
+		static const uint16_t FIN = 0x0100;
+		static const uint16_t SYN = 0x0200;
+		static const uint16_t RST = 0x0400;
+		static const uint16_t PSH = 0x0800;
+		static const uint16_t ACK = 0x1000;
+		static const uint16_t URG = 0x2000;
+		static const uint16_t ECE = 0x4000;
+		static const uint16_t CWR = 0x8000;
+		static const uint16_t NS = 0x0001;
 
 		// ATTENTION: next four elements MUST be declared sequentially without another element interrupting it
 		// because hash and compare is performed by accessing the memory directly from srcIP on
@@ -58,8 +64,8 @@ class Connection
 		uint64_t dstTransOctets; /**< host-byte order! **/
 		uint64_t srcPackets; /**< network-byte order! **/
 		uint64_t dstPackets; /**< network-byte order! **/
-		uint8_t srcTcpControlBits;
-		uint8_t dstTcpControlBits;
+		uint16_t srcTcpControlBits; /**< network-byte order! **/
+		uint16_t dstTcpControlBits; /**< network-byte order! **/
 		uint8_t protocol;
 		char* srcPayload;
 		uint32_t srcPayloadLen; /**< host-byte order! **/
@@ -80,7 +86,7 @@ class Connection
 		virtual ~Connection();
 		void addFlow(Connection* c);
 		string toString();
-		string printTcpControlBits(uint8_t bits);
+		string printTcpControlBits(uint16_t bits);
 		bool compareTo(Connection* c, bool to);
 		uint32_t getHash(bool to, uint32_t maxval);
 		void aggregate(Connection* c, uint32_t expireTime, bool to);

--- a/src/modules/ipfix/IpfixCsExporter.hpp
+++ b/src/modules/ipfix/IpfixCsExporter.hpp
@@ -120,7 +120,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 			uint16_t destination_transport_port;    // encode udp/tcp ports here
 			uint8_t  icmp_type_ipv4;
 			uint8_t  icmp_code_ipv4;
-			uint8_t  tcp_control_bits;
+			uint16_t  tcp_control_bits;
 			uint64_t flow_start_milliseconds;       // encode flowStart(Micro|Nano|)Seconds here
 			uint64_t flow_end_milliseconds;         // encode flowEnd(Micro|Nano|)Seconds here
 			uint64_t octet_total_count;
@@ -128,7 +128,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 			uint8_t  biflow_direction;
 			uint64_t rev_octet_total_count;
 			uint64_t rev_packet_total_count;
-			uint8_t  rev_tcp_control_bits;
+			uint16_t  rev_tcp_control_bits;
 		} DISABLE_ALIGNMENT;
 
 		list<Ipfix_basic_flow*> chunkList;

--- a/src/modules/ipfix/IpfixNetflowExporter.cpp
+++ b/src/modules/ipfix/IpfixNetflowExporter.cpp
@@ -168,7 +168,8 @@ void IpfixNetflowExporter::sendPacket()
 			r->last = htonl(timediff.tv_sec*1000+timediff.tv_usec/1000);
 			r->srcport = c.srcPort;
 			r->dstport = c.dstPort;
-			r->tcp_flags = c.srcTcpControlBits;
+			// As per RFCs, lose NS bit and 3 "future use" bits
+			r->tcp_flags = (uint8_t)ntohs(c.srcTcpControlBits);
 			r->prot = c.protocol;
 			record->removeReference();
 			count++;

--- a/src/modules/ipfix/IpfixPayloadWriter.cpp
+++ b/src/modules/ipfix/IpfixPayloadWriter.cpp
@@ -79,7 +79,9 @@ void IpfixPayloadWriter::onDataRecord(IpfixDataRecord* record)
 
 	if (!ignoreEmptyPayload || conn->srcPayloadLen>0 || conn->dstPayloadLen>0) {
 		if (!ignoreIncompleteTCP || conn->protocol!=6 ||
-				((conn->srcTcpControlBits&2)==2 && ((conn->dstTcpControlBits&2)==2))) { // check if both directions have SYN flag set
+				((conn->srcTcpControlBits&Connection::SYN)==Connection::SYN &&
+						((conn->dstTcpControlBits&Connection::SYN)==Connection::SYN))) {
+			// check if both directions have SYN flag set
 			if (noConnections>0) {
 				// insert entry into sorted list
 				list<Connection*>::iterator iter = connections.begin();

--- a/src/modules/ipfix/aggregator/FlowHashtable.cpp
+++ b/src/modules/ipfix/aggregator/FlowHashtable.cpp
@@ -117,8 +117,17 @@ int FlowHashtable::aggregateField(TemplateInfo::FieldInfo* basefi, TemplateInfo:
 					return 0;
 
 				case IPFIX_TYPEID_tcpControlBits:
-					ASSERT(type->length==1, "unsupported length for type");
-					*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+					/*
+					 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+					 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+					 */
+					ASSERT(type->length==1 || type->length==2,
+							"unsupported length for type tcpControlBits");
+					if (type->length==1) {
+						*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+					} else {
+						*((uint16_t*)baseData) |= *((uint16_t*)deltaData);
+					}
 					return 0;
 			}
 			break;
@@ -176,8 +185,17 @@ int FlowHashtable::aggregateField(TemplateInfo::FieldInfo* basefi, TemplateInfo:
 					return 0;
 
 				case IPFIX_TYPEID_tcpControlBits:
-					ASSERT(type->length==1, "unsupported length for type");
-					*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+					/*
+					 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+					 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+					 */
+					ASSERT(type->length==1 || type->length==2,
+							"unsupported length for type tcpControlBits");
+					if (type->length==1) {
+						*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+					} else {
+						*((uint16_t*)baseData) |= *((uint16_t*)deltaData);
+					}
 					return 0;
 
 			}

--- a/src/modules/ipfix/aggregator/PacketHashtable.cpp
+++ b/src/modules/ipfix/aggregator/PacketHashtable.cpp
@@ -283,7 +283,6 @@ void (*PacketHashtable::getCopyDataFunction(const ExpFieldData* efd))(CopyFuncPa
 		case IPFIX_PEN_reverse:
 			switch (efd->typeId.id) {
 				case IPFIX_TYPEID_protocolIdentifier:
-				case IPFIX_TYPEID_tcpControlBits:
 				case IPFIX_TYPEID_ipClassOfService:
 					if (efd->dstLength != 1) {
 						THROWEXCEPTION("unsupported length %d for type %s", efd->dstLength, efd->typeId.toString().c_str());
@@ -332,6 +331,12 @@ void (*PacketHashtable::getCopyDataFunction(const ExpFieldData* efd))(CopyFuncPa
 				case IPFIX_TYPEID_bgpSourceAsNumber:
 				case IPFIX_TYPEID_bgpDestinationAsNumber:
 					if (efd->dstLength != 2) {
+						THROWEXCEPTION("unsupported length %d for type %s", efd->dstLength, efd->typeId.toString().c_str());
+					}
+					break;
+
+				case IPFIX_TYPEID_tcpControlBits:
+					if (efd->dstLength < 1 || efd->dstLength > 2) {
 						THROWEXCEPTION("unsupported length %d for type %s", efd->dstLength, efd->typeId.toString().c_str());
 					}
 					break;
@@ -442,7 +447,6 @@ uint8_t PacketHashtable::getRawPacketFieldLength(const IeInfo& type)
 	if (type.enterprise == 0 || type.enterprise == IPFIX_PEN_reverse) {
 		switch (type.id) {
 			case IPFIX_TYPEID_protocolIdentifier:
-			case IPFIX_TYPEID_tcpControlBits:
 			case IPFIX_TYPEID_packetDeltaCount:
 			case IPFIX_TYPEID_packetTotalCount:
 			case IPFIX_TYPEID_ipClassOfService:
@@ -470,6 +474,16 @@ uint8_t PacketHashtable::getRawPacketFieldLength(const IeInfo& type)
 			case IPFIX_TYPEID_bgpSourceAsNumber:
 			case IPFIX_TYPEID_bgpDestinationAsNumber:
 				return 0;
+
+			case IPFIX_TYPEID_tcpControlBits:
+				/*
+				 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+				 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+				 */
+				if (type.length < 1 || type.length > 2) {
+					THROWEXCEPTION("unsupported length %d for type %d", type.length, type.id);
+				}
+				return type.length;
 
 			default:
 				THROWEXCEPTION("PacketHashtable: unknown typeid %s, failed to determine raw packet field length", type.toString().c_str());
@@ -580,7 +594,13 @@ uint16_t PacketHashtable::getRawPacketFieldOffset(const IeInfo& type, const Pack
 
 			case IPFIX_TYPEID_tcpControlBits:
 				if(p->ipProtocolType == Packet::TCP) {
-					return p->transportHeader + 13 - p->data.netHeader;
+					if (type.length == 1) {
+						return p->transportHeader + 13 - p->data.netHeader;
+					} else if (type.length == 2) {
+						return p->transportHeader + 12 - p->data.netHeader;
+					} else {
+						THROWEXCEPTION("unsupported length %d for type %d", type.length, type.id);
+					}
 				} else {
 					DPRINTFL(MSG_VDEBUG, "given id is %s, protocol is %d, but expected was %d", type.toString().c_str(), p->ipProtocolType, Packet::TCP);
 				}
@@ -1130,8 +1150,18 @@ void PacketHashtable::aggregateField(const ExpFieldData* efd, HashtableBucket* h
 						*(uint64_t*)baseData = htonll(ntohll(*(uint64_t*)baseData)+1);
 						break;
 
-					case IPFIX_TYPEID_tcpControlBits:  // 1 byte src and dst, bitwise-or flows
-						*(uint8_t*)baseData |= *(uint8_t*)deltaData;
+					case IPFIX_TYPEID_tcpControlBits:  // 1/2 byte src and dst, bitwise-or flows
+						/*
+						 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+						 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+						 */
+						ASSERT(efd->typeId.length == 1 || efd->typeId.length == 2,
+								"unsupported length for type tcpControlBits");
+						if (efd->typeId.length == 1) {
+							*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+						} else {
+							*((uint16_t*)baseData) |= *((uint16_t*)deltaData);
+						}
 						break;
 
 						// no other types needed, as this is only for raw field input
@@ -1195,8 +1225,18 @@ void PacketHashtable::aggregateField(const ExpFieldData* efd, HashtableBucket* h
 						*(uint64_t*)baseData = htonll(ntohll(*(uint64_t*)baseData)+1);
 						break;
 
-					case IPFIX_TYPEID_tcpControlBits: // 1 byte src and dst, bitwise-or flows
-						*(uint8_t*)baseData |= *(uint8_t*)deltaData;
+					case IPFIX_TYPEID_tcpControlBits:  // 1/2 byte src and dst, bitwise-or flows
+						/*
+						 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+						 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+						 */
+						ASSERT(efd->typeId.length==1 || efd->typeId.length==2,
+								"unsupported length for type tcpControlBits");
+						if (efd->typeId.length==1) {
+							*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+						} else {
+							*((uint16_t*)baseData) |= *((uint16_t*)deltaData);
+						}
 						break;
 
 					default:

--- a/src/modules/ipfix/aggregator/Rules.cpp
+++ b/src/modules/ipfix/aggregator/Rules.cpp
@@ -201,7 +201,7 @@ int parsePortPattern(char* s, IpfixRecord::Data** fdata, InformationElement::IeL
  * @return 0 if successful
  */
 int parseTcpFlags(char* s, IpfixRecord::Data** fdata, InformationElement::IeLength* length) {
-	uint8_t flags = 0;
+	uint16_t flags = 0;
 
 	char* p = s;
 	char* pair;
@@ -213,11 +213,14 @@ int parseTcpFlags(char* s, IpfixRecord::Data** fdata, InformationElement::IeLeng
 		else if (strcmp(pair, "PSH") == 0) flags = flags | 0x08;
 		else if (strcmp(pair, "ACK") == 0) flags = flags | 0x10;
 		else if (strcmp(pair, "URG") == 0) flags = flags | 0x20;
+		else if (strcmp(pair, "ECE") == 0) flags = flags | 0x40;
+		else if (strcmp(pair, "CWR") == 0) flags = flags | 0x80;
+		else if (strcmp(pair, "NS") == 0) flags = flags | 0x100;
 		else return -1;
 	}
 
 
-	*length = 1;
+	*length = 2;
 	IpfixRecord::Data* fd = (IpfixRecord::Data*)malloc(*length);
 	fd[0] = flags;
 	*fdata = fd;

--- a/src/modules/packet/Template.cpp
+++ b/src/modules/packet/Template.cpp
@@ -151,7 +151,17 @@ bool Template::getFieldOffsetAndHeader(const IeInfo& ie, uint16_t *offset, uint1
 				*validPacketClass = PCLASS_TRN_TCP;
 				break;
 			case IPFIX_TYPEID_tcpControlBits:
-				*offset=13;
+				/*
+				 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+				 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+				 */
+				if (ie.length == 1) {
+					*offset=13;
+				} else if (ie.length == 2) {
+					*offset=12;
+				} else {
+					THROWEXCEPTION("unsupported length %d for type %d", ie.length, ie.id);
+				}
 				*header=HEAD_TRANSPORT;
 				*validPacketClass = PCLASS_TRN_TCP;
 				break;


### PR DESCRIPTION
The new Ipfix RFCs (7011 and 7012, see http://www.iana.org/assignments/ipfix/ipfix.xhtml)
have changed the size of the tcpControlFlags from 1 byte to 2 bytes.
Some part of the code, like the ipfixlolib, already support it,
but the Ipfix Aggregator asserts when the field is not 1 byte long.

Signed-off-by: Luca Boccassi <lboccass@brocade.com>