### PR TITLE
Compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,31 @@ PROJECT(VERMONT)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.4)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 
+# TODO: Once all warnings are fixed add -Werror to both of these
+# TODO: Bonus: Remove -Wno-unused-parameter and fix all code as this one gernerates hundreds of warnings
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Wall -pedantic -Wextra -Wno-unused-parameter"
+    CACHE STRING
+    "Recommended C Flags"
+    FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -pedantic -Wextra -Wno-unused-parameter"
+    CACHE STRING
+    "Recommended C++ Flags"
+    FORCE)
+
+# Add our own specifc debug flag to the defaults
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -DDEBUG" CACHE STRING "Recommend C Debug Flags" FORCE)
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -DDEBUG" CACHE STRING "Recommend C++ Debug Flags" FORCE)
+
+IF(NOT CMAKE_BUILD_TYPE)
+  SET(CMAKE_BUILD_TYPE Release CACHE STRING
+      "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+      FORCE)
+ENDIF(NOT CMAKE_BUILD_TYPE)
+message("* Current build type is : ${CMAKE_BUILD_TYPE}")
+
 # move some config clutter to the advanced section
 MARK_AS_ADVANCED(
 	CMAKE_BACKWARDS_COMPATIBILITY
-	CMAKE_BUILD_TYPE
 	CMAKE_INSTALL_PREFIX
 	EXECUTABLE_OUTPUT_PATH
 	LIBRARY_OUTPUT_PATH
@@ -219,31 +240,6 @@ OPTION(EXPORT_TIME_SANITY_CHECK "Enable sanity checks on arrival of flows based 
 IF(EXPORT_TIME_SANITY_CHECK)
 	ADD_DEFINITIONS(-DEXPORT_TIME_SANITY_CHECK)
 ENDIF(EXPORT_TIME_SANITY_CHECK)
-
-### debug
-
-OPTION(DEBUG "Enable debug code. Vermont will run significantly slower if enabled." OFF)
-IF (DEBUG)
-	message(STATUS "Configuring build process for debug version")
-	REMOVE_DEFINITIONS(-O3)
-	
-	if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-		### FreeBSDs compilers have problems if profiling is enabled and exceptions are used
-		### with 8-STABLE and 7-STABLE (as of June 21th 2010). Some exceptions will not be 
-		### caugth if -pg is given at compile time.  We therefore disable profiling for FreeBSD
-		MESSAGE(STATUS "Detected a FreeBSD system. Not including profiling support in DEBUG mode")
-		ADD_DEFINITIONS(-O0 -g -Wall -DDEBUG)
-		SET_TARGET_PROPERTIES(vermont PROPERTIES LINK_FLAGS "-g")
-	ELSE (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-		ADD_DEFINITIONS(-O0 -g -pg -Wall -DDEBUG)
-		SET_TARGET_PROPERTIES(vermont PROPERTIES LINK_FLAGS "-g -pg")
-	ENDIF (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-ELSE (DEBUG)
-	REMOVE_DEFINITIONS(-O0 -g -pg -Wall -Werror -DDEBUG)
-	ADD_DEFINITIONS(-O3)
-	SET_TARGET_PROPERTIES(vermont PROPERTIES LINK_FLAGS "")
-ENDIF (DEBUG)
-
 
 ### PCAP_MAX_CAPTURE_LENGTH
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ PROJECT(VERMONT)
 ### CMake configuration
 
 # allow building with old CMake. Use some bundled modules as a fallback
-CMAKE_MINIMUM_REQUIRED(VERSION 2.4)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 
 # TODO: Once all warnings are fixed add -Werror to both of these
@@ -55,6 +55,8 @@ MARK_AS_ADVANCED(
 	EXECUTABLE_OUTPUT_PATH
 	LIBRARY_OUTPUT_PATH
 )
+
+include(CppcheckTargets)
 
 ### basic modules
 
@@ -98,6 +100,7 @@ INSTALL(DIRECTORY configs/
 	DESTINATION share/vermont/configs
 )
 
+add_cppcheck(vermont STYLE POSSIBLE_ERROR)
 
 ### doxygen
 

--- a/cmake/modules/CppcheckTargets.cmake
+++ b/cmake/modules/CppcheckTargets.cmake
@@ -1,0 +1,239 @@
+# - Run cppcheck on c++ source files as a custom target and a test
+#
+#  include(CppcheckTargets)
+#  add_cppcheck(<target-name> [UNUSED_FUNCTIONS] [STYLE] [POSSIBLE_ERROR] [FORCE] [FAIL_ON_WARNINGS]) -
+#    Create a target to check a target's sources with cppcheck and the indicated options
+#  add_cppcheck_sources(<target-name> [UNUSED_FUNCTIONS] [STYLE] [POSSIBLE_ERROR] [FORCE] [FAIL_ON_WARNINGS]) -
+#    Create a target to check standalone sources with cppcheck and the indicated options
+#
+# Requires these CMake modules:
+#  Findcppcheck
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__add_cppcheck)
+	return()
+endif()
+set(__add_cppcheck YES)
+
+if(NOT CPPCHECK_FOUND)
+	find_package(cppcheck QUIET)
+endif()
+
+if(NOT CPPCHECK_FOUND)
+  add_custom_target(cppcheck
+    COMMENT "cppcheck executable not found")
+  set_target_properties(cppcheck PROPERTIES EXCLUDE_FROM_ALL TRUE)
+elseif(CPPCHECK_VERSION VERSION_LESS 1.53.0)
+  add_custom_target(cppcheck
+    COMMENT "Need at least cppcheck 1.53, found ${CPPCHECK_VERSION}")
+  set_target_properties(cppcheck PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  set(CPPCHECK_FOUND)
+endif()
+
+if(NOT TARGET cppcheck)
+  add_custom_target(cppcheck)
+endif()
+
+function(add_cppcheck_sources _targetname)
+	if(CPPCHECK_FOUND)
+		set(_cppcheck_args -I ${CMAKE_SOURCE_DIR}
+                  ${CPPCHECK_EXTRA_ARGS})
+		set(_input ${ARGN})
+		list(FIND _input UNUSED_FUNCTIONS _unused_func)
+		if("${_unused_func}" GREATER "-1")
+			list(APPEND _cppcheck_args ${CPPCHECK_UNUSEDFUNC_ARG})
+			list(REMOVE_AT _input ${_unused_func})
+		endif()
+
+		list(FIND _input STYLE _style)
+		if("${_style}" GREATER "-1")
+			list(APPEND _cppcheck_args ${CPPCHECK_STYLE_ARG})
+			list(REMOVE_AT _input ${_style})
+		endif()
+
+		list(FIND _input POSSIBLE_ERROR _poss_err)
+		if("${_poss_err}" GREATER "-1")
+			list(APPEND _cppcheck_args ${CPPCHECK_POSSIBLEERROR_ARG})
+			list(REMOVE_AT _input ${_poss_err})
+		endif()
+
+		list(FIND _input FORCE _force)
+		if("${_force}" GREATER "-1")
+			list(APPEND _cppcheck_args "--force")
+			list(REMOVE_AT _input ${_force})
+		endif()
+
+		list(FIND _input FAIL_ON_WARNINGS _fail_on_warn)
+		if("${_fail_on_warn}" GREATER "-1")
+			list(APPEND
+				CPPCHECK_FAIL_REGULAR_EXPRESSION
+				${CPPCHECK_WARN_REGULAR_EXPRESSION})
+			list(REMOVE_AT _input ${_fail_on_warn})
+		endif()
+
+		set(_files)
+		foreach(_source ${_input})
+			get_source_file_property(_cppcheck_loc "${_source}" LOCATION)
+			if(_cppcheck_loc)
+				# This file has a source file property, carry on.
+				get_source_file_property(_cppcheck_lang "${_source}" LANGUAGE)
+				if(("${_cppcheck_lang}" STREQUAL "C") OR ("${_cppcheck_lang}" STREQUAL "CXX"))
+					list(APPEND _files "${_cppcheck_loc}")
+				endif()
+			else()
+				# This file doesn't have source file properties - figure it out.
+				get_filename_component(_cppcheck_loc "${_source}" ABSOLUTE)
+				if(EXISTS "${_cppcheck_loc}")
+					list(APPEND _files "${_cppcheck_loc}")
+				else()
+					message(FATAL_ERROR
+						"Adding CPPCHECK for file target ${_targetname}: "
+						"File ${_source} does not exist or needs a corrected path location "
+						"since we think its absolute path is ${_cppcheck_loc}")
+				endif()
+			endif()
+		endforeach()
+
+		if("1.${CMAKE_VERSION}" VERSION_LESS "1.2.8.0")
+			# Older than CMake 2.8.0
+			add_test(${_targetname}_cppcheck_test
+				"${CPPCHECK_EXECUTABLE}"
+				${CPPCHECK_TEMPLATE_ARG}
+				${_cppcheck_args}
+				${_files})
+		else()
+			# CMake 2.8.0 and newer
+			add_test(NAME
+				${_targetname}_cppcheck_test
+				COMMAND
+				"${CPPCHECK_EXECUTABLE}"
+				${CPPCHECK_TEMPLATE_ARG}
+				${_cppcheck_args}
+				${_files})
+		endif()
+
+		set_tests_properties(${_targetname}_cppcheck_test
+			PROPERTIES
+			FAIL_REGULAR_EXPRESSION
+			"${CPPCHECK_FAIL_REGULAR_EXPRESSION}")
+
+		add_custom_target(${_targetname}_cppcheck
+			COMMAND
+			${CPPCHECK_EXECUTABLE}
+			${CPPCHECK_QUIET_ARG}
+			${CPPCHECK_TEMPLATE_ARG}
+			${_cppcheck_args}
+			${_files}
+			WORKING_DIRECTORY
+			"${CMAKE_CURRENT_SOURCE_DIR}"
+			COMMENT
+			"${_targetname}_cppcheck: Running cppcheck on target ${_targetname}..."
+			VERBATIM)
+               add_dependencies(cppcheck ${_targetname}_cppcheck)
+	endif()
+endfunction()
+
+function(add_cppcheck _name)
+	if(NOT TARGET ${_name})
+		message(FATAL_ERROR
+			"add_cppcheck given a target name that does not exist: '${_name}' !")
+	endif()
+	if(CPPCHECK_FOUND)
+		set(_cppcheck_args -I ${CMAKE_SOURCE_DIR}
+                  ${CPPCHECK_EXTRA_ARGS})
+
+		list(FIND ARGN UNUSED_FUNCTIONS _unused_func)
+		if("${_unused_func}" GREATER "-1")
+			list(APPEND _cppcheck_args ${CPPCHECK_UNUSEDFUNC_ARG})
+		endif()
+
+		list(FIND ARGN STYLE _style)
+		if("${_style}" GREATER "-1")
+			list(APPEND _cppcheck_args ${CPPCHECK_STYLE_ARG})
+		endif()
+
+		list(FIND ARGN POSSIBLE_ERROR _poss_err)
+		if("${_poss_err}" GREATER "-1")
+			list(APPEND _cppcheck_args ${CPPCHECK_POSSIBLEERROR_ARG})
+		endif()
+
+		list(FIND ARGN FORCE _force)
+		if("${_force}" GREATER "-1")
+			list(APPEND _cppcheck_args "--force")
+		endif()
+
+		list(FIND _input FAIL_ON_WARNINGS _fail_on_warn)
+		if("${_fail_on_warn}" GREATER "-1")
+			list(APPEND
+				CPPCHECK_FAIL_REGULAR_EXPRESSION
+				${CPPCHECK_WARN_REGULAR_EXPRESSION})
+			list(REMOVE_AT _input ${_unused_func})
+		endif()
+
+		get_target_property(_cppcheck_includes "${_name}" INCLUDE_DIRECTORIES)
+		set(_includes)
+		foreach(_include ${_cppcheck_includes})
+			list(APPEND _includes "-I${_include}")
+		endforeach()
+
+		get_target_property(_cppcheck_sources "${_name}" SOURCES)
+		set(_files)
+		foreach(_source ${_cppcheck_sources})
+			get_source_file_property(_cppcheck_lang "${_source}" LANGUAGE)
+			get_source_file_property(_cppcheck_loc "${_source}" LOCATION)
+			if(("${_cppcheck_lang}" STREQUAL "C") OR ("${_cppcheck_lang}" STREQUAL "CXX"))
+				list(APPEND _files "${_cppcheck_loc}")
+			endif()
+		endforeach()
+
+		if("1.${CMAKE_VERSION}" VERSION_LESS "1.2.8.0")
+			# Older than CMake 2.8.0
+			add_test(${_name}_cppcheck_test
+				"${CPPCHECK_EXECUTABLE}"
+				${CPPCHECK_TEMPLATE_ARG}
+				${_cppcheck_args}
+				${_files})
+		else()
+			# CMake 2.8.0 and newer
+			add_test(NAME
+				${_name}_cppcheck_test
+				COMMAND
+				"${CPPCHECK_EXECUTABLE}"
+				${CPPCHECK_TEMPLATE_ARG}
+				${_cppcheck_args}
+				${_files})
+		endif()
+
+		set_tests_properties(${_name}_cppcheck_test
+			PROPERTIES
+			FAIL_REGULAR_EXPRESSION
+			"${CPPCHECK_FAIL_REGULAR_EXPRESSION}")
+
+		add_custom_target(${_name}_cppcheck
+			COMMAND
+			${CPPCHECK_EXECUTABLE}
+			${CPPCHECK_QUIET_ARG}
+			${CPPCHECK_TEMPLATE_ARG}
+			${_cppcheck_args}
+			${_includes}
+			${_files}
+			WORKING_DIRECTORY
+			"${CMAKE_CURRENT_SOURCE_DIR}"
+			COMMENT
+			"${_name}_cppcheck: Running cppcheck on target ${_name}..."
+			VERBATIM)
+               add_dependencies(cppcheck ${_name}_cppcheck)
+	endif()
+
+endfunction()

--- a/cmake/modules/Findcppcheck.cmake
+++ b/cmake/modules/Findcppcheck.cmake
@@ -1,0 +1,173 @@
+# - try to find cppcheck tool
+#
+# Cache Variables:
+#  CPPCHECK_EXECUTABLE
+#
+# Non-cache variables you might use in your CMakeLists.txt:
+#  CPPCHECK_FOUND
+#  CPPCHECK_VERSION
+#  CPPCHECK_POSSIBLEERROR_ARG
+#  CPPCHECK_UNUSEDFUNC_ARG
+#  CPPCHECK_STYLE_ARG
+#  CPPCHECK_QUIET_ARG
+#  CPPCHECK_INCLUDEPATH_ARG
+#  CPPCHECK_FAIL_REGULAR_EXPRESSION
+#  CPPCHECK_WARN_REGULAR_EXPRESSION
+#  CPPCHECK_MARK_AS_ADVANCED - whether to mark our vars as advanced even
+#    if we don't find this program.
+#
+# Requires these CMake modules:
+#  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+file(TO_CMAKE_PATH "${CPPCHECK_ROOT_DIR}" CPPCHECK_ROOT_DIR)
+set(CPPCHECK_ROOT_DIR
+	"${CPPCHECK_ROOT_DIR}"
+	CACHE
+	PATH
+	"Path to search for cppcheck")
+
+# cppcheck app bundles on Mac OS X are GUI, we want command line only
+set(_oldappbundlesetting ${CMAKE_FIND_APPBUNDLE})
+set(CMAKE_FIND_APPBUNDLE NEVER)
+
+if(CPPCHECK_EXECUTABLE AND NOT EXISTS "${CPPCHECK_EXECUTABLE}")
+	set(CPPCHECK_EXECUTABLE "notfound" CACHE PATH FORCE "")
+endif()
+
+# If we have a custom path, look there first.
+if(CPPCHECK_ROOT_DIR)
+	find_program(CPPCHECK_EXECUTABLE
+		NAMES
+		cppcheck
+		cli
+		PATHS
+		"${CPPCHECK_ROOT_DIR}"
+		PATH_SUFFIXES
+		cli
+		NO_DEFAULT_PATH)
+endif()
+
+find_program(CPPCHECK_EXECUTABLE NAMES cppcheck)
+
+# Restore original setting for appbundle finding
+set(CMAKE_FIND_APPBUNDLE ${_oldappbundlesetting})
+
+# Find out where our test file is
+get_filename_component(_cppcheckmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+set(_cppcheckdummyfile "${_cppcheckmoddir}/Findcppcheck.cpp")
+if(NOT EXISTS "${_cppcheckdummyfile}")
+	message(FATAL_ERROR
+		"Missing file ${_cppcheckdummyfile} - should be alongside Findcppcheck.cmake, can be found at https://github.com/rpavlik/cmake-modules")
+endif()
+
+function(_cppcheck_test_arg _resultvar _arg)
+	if(NOT CPPCHECK_EXECUTABLE)
+		set(${_resultvar} NO)
+		return()
+	endif()
+	execute_process(COMMAND
+		"${CPPCHECK_EXECUTABLE}"
+		"${_arg}"
+		"--quiet"
+		"${_cppcheckdummyfile}"
+		RESULT_VARIABLE
+		_cppcheck_result
+		OUTPUT_QUIET
+		ERROR_QUIET)
+	if("${_cppcheck_result}" EQUAL 0)
+		set(${_resultvar} YES PARENT_SCOPE)
+	else()
+		set(${_resultvar} NO PARENT_SCOPE)
+	endif()
+endfunction()
+
+function(_cppcheck_set_arg_var _argvar _arg)
+	if("${${_argvar}}" STREQUAL "")
+		_cppcheck_test_arg(_cppcheck_arg "${_arg}")
+		if(_cppcheck_arg)
+			set(${_argvar} "${_arg}" PARENT_SCOPE)
+		endif()
+	endif()
+endfunction()
+
+if(CPPCHECK_EXECUTABLE)
+
+	# Check for the two types of command line arguments by just trying them
+	_cppcheck_set_arg_var(CPPCHECK_STYLE_ARG "--enable=style")
+	_cppcheck_set_arg_var(CPPCHECK_STYLE_ARG "--style")
+	if("${CPPCHECK_STYLE_ARG}" STREQUAL "--enable=style")
+
+		_cppcheck_set_arg_var(CPPCHECK_UNUSEDFUNC_ARG
+			"--enable=unusedFunction")
+		_cppcheck_set_arg_var(CPPCHECK_INFORMATION_ARG "--enable=information")
+		_cppcheck_set_arg_var(CPPCHECK_MISSINGINCLUDE_ARG
+			"--enable=missingInclude")
+		_cppcheck_set_arg_var(CPPCHECK_POSIX_ARG "--enable=posix")
+		_cppcheck_set_arg_var(CPPCHECK_POSSIBLEERROR_ARG
+			"--enable=possibleError")
+		_cppcheck_set_arg_var(CPPCHECK_POSSIBLEERROR_ARG "--enable=all")
+
+		if(MSVC)
+			set(CPPCHECK_TEMPLATE_ARG --template vs)
+			set(CPPCHECK_FAIL_REGULAR_EXPRESSION "[(]error[)]")
+			set(CPPCHECK_WARN_REGULAR_EXPRESSION "[(]style[)]")
+		elseif(CMAKE_COMPILER_IS_GNUCXX)
+			set(CPPCHECK_TEMPLATE_ARG --template gcc)
+			set(CPPCHECK_FAIL_REGULAR_EXPRESSION " error: ")
+			set(CPPCHECK_WARN_REGULAR_EXPRESSION " style: ")
+		else()
+			set(CPPCHECK_TEMPLATE_ARG --template gcc)
+			set(CPPCHECK_FAIL_REGULAR_EXPRESSION " error: ")
+			set(CPPCHECK_WARN_REGULAR_EXPRESSION " style: ")
+		endif()
+	elseif("${CPPCHECK_STYLE_ARG}" STREQUAL "--style")
+		# Old arguments
+		_cppcheck_set_arg_var(CPPCHECK_UNUSEDFUNC_ARG "--unused-functions")
+		_cppcheck_set_arg_var(CPPCHECK_POSSIBLEERROR_ARG "--all")
+		set(CPPCHECK_FAIL_REGULAR_EXPRESSION "error:")
+		set(CPPCHECK_WARN_REGULAR_EXPRESSION "[(]style[)]")
+	else()
+		# No idea - some other issue must be getting in the way
+		message(STATUS
+			"WARNING: Can't detect whether CPPCHECK wants new or old-style arguments!")
+	endif()
+
+	set(CPPCHECK_QUIET_ARG "--quiet")
+	set(CPPCHECK_INCLUDEPATH_ARG "-I")
+
+endif()
+
+set(CPPCHECK_ALL
+	"${CPPCHECK_EXECUTABLE} ${CPPCHECK_POSSIBLEERROR_ARG} ${CPPCHECK_UNUSEDFUNC_ARG} ${CPPCHECK_STYLE_ARG} ${CPPCHECK_QUIET_ARG} ${CPPCHECK_INCLUDEPATH_ARG} some/include/path")
+
+execute_process(COMMAND "${CPPCHECK_EXECUTABLE}" --version
+  OUTPUT_VARIABLE CPPCHECK_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+string(REGEX REPLACE ".* ([0-9]\\.([0-9]\\.[0-9])?)" "\\1"
+    CPPCHECK_VERSION "${CPPCHECK_VERSION}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(cppcheck
+	DEFAULT_MSG
+	CPPCHECK_ALL
+	CPPCHECK_EXECUTABLE
+	CPPCHECK_POSSIBLEERROR_ARG
+	CPPCHECK_UNUSEDFUNC_ARG
+	CPPCHECK_STYLE_ARG
+	CPPCHECK_INCLUDEPATH_ARG
+	CPPCHECK_QUIET_ARG)
+
+if(CPPCHECK_FOUND OR CPPCHECK_MARK_AS_ADVANCED)
+	mark_as_advanced(CPPCHECK_ROOT_DIR)
+endif()
+
+mark_as_advanced(CPPCHECK_EXECUTABLE)

--- a/cmake/modules/Findcppcheck.cpp
+++ b/cmake/modules/Findcppcheck.cpp
@@ -1,0 +1,16 @@
+/**
+ * \file Findcppcheck.cpp
+ * \brief Dummy C++ source file used by CMake module Findcppcheck.cmake
+ *
+ * \author
+ * Ryan Pavlik, 2009-2010
+ * <rpavlik@iastate.edu>
+ * http://academic.cleardefinition.com/
+ *
+ */
+
+
+
+int main(int argc, char* argv[]) {
+	return 0;
+}

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -36,6 +36,8 @@ ADD_LIBRARY(common
 	openssl/SSLCTXWrapper.cpp
 )
 
+add_cppcheck(common STYLE POSSIBLE_ERROR)
+
 SUBDIRS(
 	anon
 	ipfixlolib	

--- a/src/common/anon/RandomNumberGenerator.h
+++ b/src/common/anon/RandomNumberGenerator.h
@@ -33,7 +33,7 @@ namespace RandomNumberGenerator {
 	unsigned int generate();
 	unsigned int generate(unsigned int rangemin, unsigned int rangemax);
 
-};
+}
 
 #endif // __RANDOM_NUMBER_GENERATOR_H
 

--- a/src/common/ipfixlolib/CMakeLists.txt
+++ b/src/common/ipfixlolib/CMakeLists.txt
@@ -24,3 +24,4 @@ ADD_LIBRARY(ipfixlolib
 	ipfix_names.c
 )
 
+add_cppcheck(ipfixlolib STYLE POSSIBLE_ERROR)

--- a/src/common/ipfixlolib/ipfixlolib.c
+++ b/src/common/ipfixlolib/ipfixlolib.c
@@ -1599,7 +1599,7 @@ static void ipfix_prepend_header(ipfix_exporter *p_exporter, int data_length, ip
         } else {
                 // compute it on our own:
                 // sum up all lengths in the iovecs:
-                int i;
+                unsigned int i;
 
                 // start the loop with 1, as 0 is reserved for the header!
                 for (i = 1; i< sendbuf->current;  i++) {
@@ -2332,7 +2332,9 @@ static int ipfix_send_templates(ipfix_exporter* exporter)
 							msg(MSG_VDEBUG, "%d template bytes sent to SCTP collector %s:%d",
 								bytes_sent, col->ipv4address, col->port_number);
 						}
-					} else DPRINTF("No Template to send to SCTP collector");
+					} else {
+					    DPRINTF("No Template to send to SCTP collector");
+					}
 					break;	
 				default:
 				msg(MSG_FATAL, "Unknown collector socket state");
@@ -2847,7 +2849,7 @@ int ipfix_cancel_data_set(ipfix_exporter *exporter)
 {
 	ipfix_set_manager *manager = &(exporter->data_sendbuffer->set_manager);
 	unsigned current = manager->set_counter;
-	int i;
+	unsigned int i;
 
 	// security check
 	if(exporter->data_sendbuffer->current == exporter->data_sendbuffer->committed) {

--- a/src/common/ipfixlolib/ipfixlolib.c
+++ b/src/common/ipfixlolib/ipfixlolib.c
@@ -1175,7 +1175,7 @@ static int add_collector_dtls(
 
     // we need aux_config for setting up a DTLS collector
     if (!aux_config) {
-        return -1
+        return -1;
     }
 
     ipfix_aux_config_dtls *aux_config_dtls;

--- a/src/common/ipfixlolib/ipfixlolib.c
+++ b/src/common/ipfixlolib/ipfixlolib.c
@@ -2433,7 +2433,7 @@ static int ipfix_send_data(ipfix_exporter* exporter)
                                 DPRINTFL(MSG_VDEBUG, "Sendbuffer contains %u bytes (Set headers + records)",  exporter->data_sendbuffer->committed_data_length );
                                 DPRINTFL(MSG_VDEBUG, "Sendbuffer contains %u fields (IPFIX Message header + set headers + records)",  exporter->data_sendbuffer->committed );
                                 int tested_length = 0;
-                                int j;
+                                unsigned int j;
                                 /*int k;*/
                                 for (j =0; j <  exporter->data_sendbuffer->committed; j++) {
                                         if(exporter->data_sendbuffer->entries[j].iov_len > 0 ) {
@@ -2982,7 +2982,7 @@ int ipfix_start_datatemplate (ipfix_exporter *exporter,
        Data Templates are (still) a proprietary extension to IPFIX. */
     int datatemplate=(fixedfield_count || preceding) ? 1 : 0;
     /* Make sure that template_id is > 255 */
-    if ( ! template_id > 255 ) {
+    if (!(template_id > 255)) {
 	msg(MSG_ERROR, "Template id has to be > 255. Start of template cancelled.");
 	return -1;
     }

--- a/src/common/ipfixlolib/ipfixlolib.c
+++ b/src/common/ipfixlolib/ipfixlolib.c
@@ -2270,7 +2270,7 @@ static int ipfix_send_templates(ipfix_exporter* exporter)
 							    col->port_number);
 						} else {
 						    msg(MSG_ERROR,
-							    "could not send to %s:%d errno: %s  (UDP)",
+							    "could not send templates to %s:%d errno: %s  (UDP)",
 							    col->ipv4address,
 							    col->port_number,
 							    strerror(errno));
@@ -2319,7 +2319,7 @@ static int ipfix_send_templates(ipfix_exporter* exporter)
 							0 // context
 							)) == -1) {
 							// send failed
-							msg(MSG_ERROR, "could not send to %s:%d errno: %s  (SCTP)",col->ipv4address, col->port_number, strerror(errno));
+							msg(MSG_ERROR, "could not send templates to %s:%d errno: %s  (SCTP)",col->ipv4address, col->port_number, strerror(errno));
 							sctp_reconnect(exporter, i); //1st reconnect attempt 
 							// if result is C_DISCONNECTED and sctp_reconnect_timer == 0, collector will 
 							// be removed on the next call of ipfix_send_templates()
@@ -2454,7 +2454,7 @@ static int ipfix_send_data(ipfix_exporter* exporter)
 						exporter->data_sendbuffer->entries,
 						exporter->data_sendbuffer->committed
 							     )) == -1){
-						msg(MSG_ERROR, "could not send to %s:%d errno: %s  (UDP)",col->ipv4address, col->port_number, strerror(errno));
+						msg(MSG_ERROR, "could not send data to %s:%d errno: %s  (UDP)",col->ipv4address, col->port_number, strerror(errno));
 						if (errno == EMSGSIZE) {
 						    msg(MSG_ERROR, "Updating MTU estimate for collector %s:%d",
 							    col->ipv4address,
@@ -2478,7 +2478,7 @@ static int ipfix_send_data(ipfix_exporter* exporter)
 						exporter->data_sendbuffer->committed,
 						exporter->sctp_lifetime
 							     )) == -1){
-						msg(MSG_VDEBUG, "could not send to %s:%d (DTLS over SCTP)",col->ipv4address, col->port_number);
+						msg(MSG_VDEBUG, "could not send data to %s:%d (DTLS over SCTP)",col->ipv4address, col->port_number);
 					}else{
 
 						msg(MSG_VDEBUG, "%d data bytes sent to DTLS over SCTP collector %s:%d",
@@ -2500,7 +2500,7 @@ static int ipfix_send_data(ipfix_exporter* exporter)
 						0 // context
 						)) == -1) {
 						// send failed
-						msg(MSG_ERROR, "could not send to %s:%d errno: %s  (SCTP)",col->ipv4address, col->port_number, strerror(errno));
+						msg(MSG_ERROR, "could not send data to %s:%d errno: %s  (SCTP)",col->ipv4address, col->port_number, strerror(errno));
 						// drop data and call sctp_reconnect
 						sctp_reconnect(exporter, i);
 						// if result is C_DISCONNECTED and sctp_reconnect_timer == 0, collector will 
@@ -2516,7 +2516,7 @@ static int ipfix_send_data(ipfix_exporter* exporter)
 						exporter->data_sendbuffer->entries,
 						exporter->data_sendbuffer->committed
 							     )) == -1){
-						msg(MSG_VDEBUG, "could not send to %s:%d (DTLS over UDP)",col->ipv4address, col->port_number);
+						msg(MSG_VDEBUG, "could not send data to %s:%d (DTLS over UDP)",col->ipv4address, col->port_number);
 					}else{
 
 						msg(MSG_VDEBUG, "%d data bytes sent to DTLS over UDP collector %s:%d",

--- a/src/common/ipfixlolib/ipfixlolib.h
+++ b/src/common/ipfixlolib/ipfixlolib.h
@@ -492,7 +492,7 @@ typedef struct {
  */
 typedef struct {
 	char ipv4address[16];
-	uint32_t port_number;
+	uint16_t port_number;
 	enum ipfix_transport_protocol protocol;
 	int data_socket; // socket data and templates are sent to
 	/* data_socket is NOT used for DTLS connections */
@@ -613,8 +613,8 @@ int ipfix_beat(ipfix_exporter *exporter);
 int ipfix_init_exporter(uint32_t observation_domain_id, ipfix_exporter **exporter);
 int ipfix_deinit_exporter(ipfix_exporter *exporter);
 
-int ipfix_add_collector(ipfix_exporter *exporter, const char *coll_ip4_addr, int coll_port, enum ipfix_transport_protocol proto, void *aux_config);
-int ipfix_remove_collector(ipfix_exporter *exporter, const char *coll_ip4_addr, int coll_port);
+int ipfix_add_collector(ipfix_exporter *exporter, const char *coll_ip4_addr, uint16_t coll_port, enum ipfix_transport_protocol proto, void *aux_config);
+int ipfix_remove_collector(ipfix_exporter *exporter, const char *coll_ip4_addr, uint16_t coll_port);
 int ipfix_start_template(ipfix_exporter *exporter, uint16_t template_id,  uint16_t field_count);
 int ipfix_start_optionstemplate_set(ipfix_exporter *exporter, uint16_t template_id, uint16_t scope_length, uint16_t option_length);
 int ipfix_start_datatemplate(ipfix_exporter *exporter, uint16_t template_id, uint16_t preceding, uint16_t field_count, uint16_t fixedfield_count);

--- a/src/common/msg.h
+++ b/src/common/msg.h
@@ -65,14 +65,14 @@ void vermont_exception(const int, const char*, const char*, const char*, const c
 //#endif
 
 // useful defines for logging
-#define THROWEXCEPTION(fmt, args...) vermont_exception(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, fmt, ##args)
+#define THROWEXCEPTION(...) vermont_exception(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, ##__VA_ARGS__)
 
-#define msg(lvl, fmt, args...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, lvl, fmt, ##args)
+#define msg(...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, ##__VA_ARGS__)
 
 #ifdef DEBUG
 
-#define DPRINTF(fmt, args...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, MSG_DEBUG, fmt, ##args)
-#define DPRINTFL(lvl, fmt, args...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, lvl, fmt, ##args)
+#define DPRINTF(...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, MSG_DEBUG, ##__VA_ARGS__)
+#define DPRINTFL(...) msg2(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, ##__VA_ARGS__)
 
 #define ASSERT(exp, description)                                                                        \
     {                                                                                                   \
@@ -84,8 +84,8 @@ void vermont_exception(const int, const char*, const char*, const char*, const c
 
 #else
 
-#define DPRINTF(fmt, args...)
-#define DPRINTFL(lvl, fmt, args...)
+#define DPRINTF(...)
+#define DPRINTFL(...)
 #define ASSERT(exp, description)
 
 #endif

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,3 +15,4 @@ ADD_LIBRARY(core
 	XMLTextNode.cpp
 )
 
+add_cppcheck(core STYLE POSSIBLE_ERROR)

--- a/src/core/Module.cpp
+++ b/src/core/Module.cpp
@@ -7,7 +7,7 @@
 Module::Module() 
 	: exitFlag(false), running(false)
 { 
-};
+}
 
 
 Module::~Module()

--- a/src/core/XMLAttribute.h
+++ b/src/core/XMLAttribute.h
@@ -24,7 +24,7 @@ protected:
 		return reinterpret_cast<xmlAttrPtr>(XMLNode::cobj());
 	}
 
-	inline const xmlAttrPtr cobj() const
+	inline xmlAttrPtr cobj() const
 	{
 		return reinterpret_cast<const xmlAttrPtr>(XMLNode::cobj());
 	}

--- a/src/core/XMLNode.h
+++ b/src/core/XMLNode.h
@@ -84,7 +84,7 @@ protected:
 		return xmlNode;
 	}
 
-	inline const xmlNodePtr cobj() const {
+	inline xmlNodePtr cobj() const {
 		return xmlNode;
 	}
 

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -122,4 +122,4 @@ ADD_LIBRARY(modules
     ipfix/database/IpfixFlowInspectorExporter.cpp
 )
 
-
+add_cppcheck(modules STYLE POSSIBLE_ERROR)

--- a/src/modules/ipfix/IpfixCsExporter.hpp
+++ b/src/modules/ipfix/IpfixCsExporter.hpp
@@ -97,7 +97,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 
 		struct CS_Ipfix_file_header {
 			uint8_t magic[8]; //expected: CS_IPFIX_MAGIC
-		} DISABLE_ALIGNMENT;
+		} DISABLE_ALIGNMENT
 
 		/**
 		 * class representing the start of a chunk in the CS format
@@ -106,7 +106,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 			uint16_t ipfix_type; //-> CS_IPFIX_CHUNK_TYPE -> 0x0008
 			uint32_t chunk_length; //number of bytes in chunk starting after this element, this should be flow_count*sizeof(Ipfix_basic_flow)+4
 			uint32_t flow_count; //number of Ipfix_basic_flow records to follow
-		} DISABLE_ALIGNMENT;
+		} DISABLE_ALIGNMENT
 
 		struct Ipfix_basic_flow {
 			uint16_t record_length;                 // total length of this record minus length of this element
@@ -129,7 +129,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 			uint64_t rev_octet_total_count;
 			uint64_t rev_packet_total_count;
 			uint8_t  rev_tcp_control_bits;
-		} DISABLE_ALIGNMENT;
+		} DISABLE_ALIGNMENT
 
 		list<Ipfix_basic_flow*> chunkList;
 		uint32_t chunkListSize;

--- a/src/modules/ipfix/IpfixPrinter.cpp
+++ b/src/modules/ipfix/IpfixPrinter.cpp
@@ -152,7 +152,7 @@ void PrintHelpers::printUint(InformationElement::IeInfo type, IpfixRecord::Data*
 		fprintf(fh, "%u",ntohl(*(uint32_t*)data));
 		return;
 	case 8:
-		fprintf(fh, "%Lu",(long long unsigned)ntohll(*(uint64_t*)data));
+		fprintf(fh, "%llu",(long long unsigned)ntohll(*(uint64_t*)data));
 		return;
 	default:
 		for(uint16_t i = 0; i < type.length; i++) {
@@ -188,7 +188,7 @@ void PrintHelpers::printLocaltime(InformationElement::IeInfo type, IpfixRecord::
 		ctime_r(&tmp, str);
 		// remove new line
 		str[24] = '\0';
-		fprintf(fh, "%Lu (%s)", (long long unsigned)ntohll(*(uint64_t*)data), str);
+		fprintf(fh, "%llu (%s)", (long long unsigned)ntohll(*(uint64_t*)data), str);
 		return;
 	default:
 		for(uint16_t i = 0; i < type.length; i++) {

--- a/src/modules/ipfix/IpfixReceiverDtlsUdpIpV4.hpp
+++ b/src/modules/ipfix/IpfixReceiverDtlsUdpIpV4.hpp
@@ -62,7 +62,7 @@ class IpfixReceiverDtlsUdpIpV4 : public IpfixReceiver, Sensor {
 	IpfixReceiverDtlsUdpIpV4(int port, const std::string ipAddr = "",
 	    const std::string &certificateChainFile = "", const std::string &privateKeyFile = "",
 	    const std::string &caFile = "", const std::string &caPath = "",
-	    const std::set<string> &peerFqdns = std::set<string>(), const uint32_t buffer);
+	    const std::set<string> &peerFqdns = std::set<string>(), const uint32_t buffer = 0);
 	virtual ~IpfixReceiverDtlsUdpIpV4();
 
 	virtual void run();

--- a/src/modules/ipfix/IpfixReceiverFile.cpp
+++ b/src/modules/ipfix/IpfixReceiverFile.cpp
@@ -196,11 +196,13 @@ void IpfixReceiverFile::run()
 			/*reset the filepointer to the begin of the message*/
 			packetFile.seekg(-(int)(sizeof(uint32_t)), std::ios::cur); 
 
+			/** @todo uint_16 can never be > 65536
 			if (n > MAX_MSG_LEN) {
 				msg(MSG_ERROR, "IpfixReceiverFile: packet at idx=%u too big with n=%u in file \"%s\"", 
 						idx, n, packet_file_path.c_str());
 				continue;
 			}
+*/
 
 			data.reset(new uint8_t[MAX_MSG_LEN]);
 			packetFile.read(reinterpret_cast<char*>(data.get()), n);

--- a/src/modules/ipfix/IpfixRecord.cpp
+++ b/src/modules/ipfix/IpfixRecord.cpp
@@ -80,7 +80,7 @@ namespace InformationElement {
 	/**
 	 * @returns valid protocols for given field, binary ORed if multiple protocols are possible
 	 */
-	const Packet::IPProtocolType IeInfo::getValidProtocols()
+	Packet::IPProtocolType IeInfo::getValidProtocols()
 	{
 		if (enterprise==0 || enterprise==IPFIX_PEN_reverse) {
 			switch (id) {

--- a/src/modules/ipfix/IpfixRecord.hpp
+++ b/src/modules/ipfix/IpfixRecord.hpp
@@ -82,7 +82,7 @@ namespace InformationElement {
 
 		bool isReverseField() const;
 		IeInfo getReverseDirection();
-		const Packet::IPProtocolType getValidProtocols();
+		Packet::IPProtocolType getValidProtocols();
 		string toString() const;
 		bool existsReverseDirection();
 	};

--- a/src/modules/ipfix/aggregator/BaseHashtable.cpp
+++ b/src/modules/ipfix/aggregator/BaseHashtable.cpp
@@ -315,10 +315,11 @@ void BaseHashtable::expireFlows(bool all)
 			// problem here: flows with active timeout may be exported passive timeout seconds too late
 			// now must be updated by the child classes
 			if ((bucket->expireTime < now) || (bucket->forceExpireTime < now) || all) {
-				if (now > bucket->forceExpireTime)
+				if (now > bucket->forceExpireTime) {
 					DPRINTF("expireFlows: forced expiry");
-				else if (now > bucket->expireTime)
+				} else if (now > bucket->expireTime) {
 					DPRINTF("expireFlows: normal expiry");
+				}
 				if (bucket->inTable) removeBucket(bucket);
 				statExportedBuckets++;
 				exportBucket(bucket);

--- a/src/modules/packet/Observer.cpp
+++ b/src/modules/packet/Observer.cpp
@@ -105,7 +105,7 @@ Observer::Observer(const std::string& interface, bool offline, uint64_t maxpacke
 				"adjust compile-time parameter PCAP_MAX_CAPTURE_LENGTH!", capturelen, PCAP_DEFAULT_CAPTURE_LENGTH);
 
 	}
-};
+}
 
 Observer::~Observer()
 {
@@ -475,7 +475,7 @@ void Observer::performStart()
 
 	msg(MSG_DEBUG, "now starting capturing thread");
 	thread.run(this);
-};
+}
 
 void Observer::performShutdown()
 {

--- a/src/modules/packet/PSAMPExporterModule.cpp
+++ b/src/modules/packet/PSAMPExporterModule.cpp
@@ -66,7 +66,7 @@ PSAMPExporterModule::~PSAMPExporterModule()
         for (int i = 0; i < numPacketsToRelease; i++) {
 		(packetsToRelease[i])->removeReference();
 	}
-};
+}
 
 
 void PSAMPExporterModule::startNewPacketStream()

--- a/src/modules/packet/filter/RandomSampler.cpp
+++ b/src/modules/packet/filter/RandomSampler.cpp
@@ -68,7 +68,7 @@ RandomSampler::RandomSampler(int n, int N) : samplingSize(N), acceptSize(n), cur
 
                 sampleMask[pos] = true;
         }
-};
+}
 
 bool RandomSampler::processPacket(Packet *p)
 {

--- a/src/modules/packet/filter/RegExFilter.cpp
+++ b/src/modules/packet/filter/RegExFilter.cpp
@@ -31,7 +31,7 @@ inline bool RegExFilter::compare(char *pdata)
 
 	return false;
 
-};
+}
 
 bool RegExFilter::processPacket(Packet* p)
 {
@@ -49,4 +49,4 @@ bool RegExFilter::processPacket(Packet* p)
 
 	return result;
 
-};
+}

--- a/src/modules/packet/filter/StringFilter.cpp
+++ b/src/modules/packet/filter/StringFilter.cpp
@@ -97,7 +97,7 @@ inline bool StringFilter::compare(unsigned char *pdata, std::string toMatch, uns
     }
     return false;
 
-};
+}
 
 /**
  * prepare the Packet for comparefucntion
@@ -128,4 +128,4 @@ bool StringFilter::processPacket(Packet *p)
 	    return false;
 
     return true;
-};
+}

--- a/src/tests/ipfixlolib/example_code_2.c
+++ b/src/tests/ipfixlolib/example_code_2.c
@@ -59,7 +59,7 @@ typedef struct {
 } meter_data;
 
 meter_data my_meter_data[10000];
-int my_meter_data_next_free = 0;
+unsigned int my_meter_data_next_free = 0;
 
 
 int parse_command_line_arguments(int argc, char **argv);

--- a/src/tests/ipfixlolib/mtutest.c
+++ b/src/tests/ipfixlolib/mtutest.c
@@ -38,7 +38,7 @@ void define_template(ipfix_exporter *exporter) {
 void put_data(ipfix_exporter *exporter) {
 	uint8_t data[256];
 	uint8_t i = 0;
-	int j;
+	unsigned int j;
 	int s;
 	for (j=0;j<sizeof(data);j++) {
 		data[j] = j;

--- a/src/tests/ipfixlolib/test_everything.cc
+++ b/src/tests/ipfixlolib/test_everything.cc
@@ -20,7 +20,9 @@ int print_usage(void){
 	
 	printf("How To Use Tests:\n\n");
 	printf("\t--- Just what you are reading: \th \n");
+#ifdef SUPPORT_SCTP
 	printf("\t--- Create SCTP collector: \tc \n");
+#endif
 	printf("\t--- Create UDP collector: \tu \n");
 	printf("\t--- Template creation: \t\tt \n");
 	printf("\t--- Template creation with custom ID: \tT 777 \n");
@@ -134,7 +136,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'd':
 			//delete template
-			assert(scanf("%d",&delete_id)==1);
+			assert(scanf("%u",&delete_id)==1);
 			printf("Start testing Template destruction ID : %d!\n", delete_id);
 			
 			ret=ipfix_remove_template(my_exporter, delete_id);
@@ -189,6 +191,8 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "ipfix_remove_collector failed!\n");
 		exit(-1);
 	}
+*/
+#ifdef SUPPORT_SCTP
 	if(sctp_exists){
 		
 		printf("Remove  SCTP Collector!\n");
@@ -198,7 +202,7 @@ int main(int argc, char *argv[])
 			exit(-1);
 		}
 	}
-*/	
+#endif
 	printf("deinit exporter!\n");
 	
 	ipfix_deinit_exporter(my_exporter);

--- a/src/tests/vermonttest/TestSuiteBase.h
+++ b/src/tests/vermonttest/TestSuiteBase.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 
-#define ERROR(fmt, args...) vermont_exception(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, fmt, ##args)
+#define ERROR(...) vermont_exception(__LINE__, __FILE__, __PRETTY_FUNCTION__, __func__, ##__VA_ARGS__)
 
 // redefine assert, so that ASSERT is always properly defined in unit tests
 #undef ASSERT


### PR DESCRIPTION
The goal is fix them all so that it can be compiled with:
```bash
CFLAGS="-std=gnu11 -Werror -Wall -Wextra -pedantic" CXXFLAGS="-std=gnu++11 -Werror -Wall -Wextra -pedantic" cmake ../vermont
```
for the moment it compiles with:
```bash
CFLAGS="-std=gnu11 -Wall -Wextra -pedantic" CXXFLAGS="-std=gnu++11 -Wall -Wextra -pedantic" cmake ../vermont
```