### PR TITLE
Improve CollectorCfg::equalTo()

### DIFF
--- a/src/modules/ipfix/CollectorCfg.h
+++ b/src/modules/ipfix/CollectorCfg.h
@@ -99,6 +99,12 @@ public:
 			}
 		}
 		if (port==0) port = defaultPort;
+
+		/*
+		 * Sort the lists here, so that in equalTo() we can return True even if
+		 * the order does not match, since what we care about is the content
+		 */
+		std::sort(authorizedHosts.begin(), authorizedHosts.end());
 	}
 
 	IpfixReceiver* createIpfixReceiver(
@@ -142,10 +148,7 @@ public:
 			(mtu == other->mtu) &&
 			(peerFqdns == other->peerFqdns) &&
 			(buffer == other->buffer) &&
-			(authorizedHosts.size() == other->authorizedHosts.size())) {
-			for (uint16_t i = 0; i < authorizedHosts.size(); i++)
-				if (authorizedHosts[i] != other->authorizedHosts[i])
-					return false;	
+			(authorizedHosts == other->authorizedHosts)) {
 			return true;
 		}
 


### PR DESCRIPTION
Simplify equalTo list comparison thanks to
std vector comparison.
Sort vector in costructor so that equalTo will return True
if the content is the same, even if the order is scrambled,
since the entries order is not relevant.

At the moment, if the order of the strings in authorizedHosts is not the same, equalTo will return false. Since the order does not matter, sort the array in the costructor and then use the standard library vector comparison to compare them.