### PR TITLE
Add option to disable auto add v4 mask

### DIFF
--- a/src/core/InfoElementCfg.h
+++ b/src/core/InfoElementCfg.h
@@ -21,6 +21,8 @@ public:
 		ieName	         = getOptional("ieName");
 		modifier         = getOptional("modifier");
 		match            = getOptional("match");
+		autoAddV4PrefixLength = getBool("autoAddV4PrefixLength", true);
+
 
 		if (ieId>0) {
 			// check if ieID is known to Vermont
@@ -82,6 +84,19 @@ public:
 
 	bool isKnownIE() { return knownIE; }
 
+	bool getAutoAddV4PrefixLength() { return autoAddV4PrefixLength; }
+
+	bool operator==(const InfoElementCfg &other) const {
+		if (other.ieLength != ieLength) return false;
+		if (other.ieId != ieId) return true;
+		if (other.enterpriseNumber != enterpriseNumber) return false;
+		if (other.ieName != ieName) return false;
+		if (other.modifier != modifier) return false;
+		if (other.match != match) return false;
+		if (other.autoAddV4PrefixLength != autoAddV4PrefixLength) return false;
+		return true;
+	}
+
 private:
 	std::string ieName;
 	uint16_t ieLength;
@@ -92,6 +107,7 @@ private:
 	std::string modifier;
 
 	bool knownIE;
+	bool autoAddV4PrefixLength;
 };
 
 #endif /*INFOELEMENTCFG_H_*/

--- a/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
+++ b/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
@@ -124,8 +124,9 @@ Rule::Field* AggregatorBaseCfg::readNonFlowKeyRule(XMLElement* e)
 	ruleField->type.enterprise = ie.getEnterpriseNumber();
 	ruleField->type.length = ie.getIeLength();
 
-	if ((ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_sourceIPv4Address, 0)) ||
-			(ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_destinationIPv4Address, 0))) {
+	if (ie.getAutoAddV4PrefixLength() &&
+			(ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_sourceIPv4Address, 0) ||
+			ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_destinationIPv4Address, 0))) {
 		ruleField->type.length++; // for additional mask field
 	}
 
@@ -161,7 +162,8 @@ Rule::Field* AggregatorBaseCfg::readFlowKeyRule(XMLElement* e) {
 		ruleField->type.enterprise = ie.getEnterpriseNumber();
 		ruleField->type.length = ie.getIeLength();
 
-		if ((ruleField->type.id == IPFIX_TYPEID_sourceIPv4Address) || (ruleField->type.id == IPFIX_TYPEID_destinationIPv4Address)) {
+		if (ie.getAutoAddV4PrefixLength() &&
+				(ruleField->type.id == IPFIX_TYPEID_sourceIPv4Address || ruleField->type.id == IPFIX_TYPEID_destinationIPv4Address)) {
 			ruleField->type.length++; // for additional mask field
 		}
 


### PR DESCRIPTION
This commit adds the option (opt-out) to stop the aggregator from automatically generating a subnet mask for IPv4 source and destination addresses.

This is necessary because if the flow already has the fields, they will be duplicated (and very likely with different values), which is confusing.

The default behaviour is "enabled", so that backward compatibility is not broken and old configs will work just the same.