### PR TITLE
Add statistic to aggregator sensor and fix total entries statistic for flow aggregators

### DIFF
--- a/src/modules/ipfix/aggregator/BaseHashtable.cpp
+++ b/src/modules/ipfix/aggregator/BaseHashtable.cpp
@@ -488,6 +488,7 @@ std::string BaseHashtable::getStatisticsXML(double interval)
 	uint32_t diff = statExportedBuckets - statLastExpBuckets;
 	statLastExpBuckets += diff;
 	oss << "<exportedEntries>" << (uint32_t) ((double) diff / interval) << "</exportedEntries>";
+	oss << "<totalExportedEntries>" << statExportedBuckets << "</totalExportedEntries>";
 	return oss.str();
 }
 

--- a/src/modules/ipfix/aggregator/FlowHashtable.cpp
+++ b/src/modules/ipfix/aggregator/FlowHashtable.cpp
@@ -518,6 +518,7 @@ void FlowHashtable::bufferDataBlock(boost::shared_array<IpfixRecord::Data> data,
 	}
 	if (!flowfound || expiryforced) {
 		DPRINTFL(MSG_VDEBUG, "creating new bucket");
+		statTotalEntries++;
 		HashtableBucket* n = buckets[nhash];
 		buckets[nhash] = createBucket(data, 0, n, 0, nhash, flowStartTimeSeconds); // FIXME: insert observationDomainID!
 		buckets[nhash]->inTable = true;


### PR DESCRIPTION
This pull request makes a couple of changes to the sensor statistics for the aggregator modules. Firstly, it adds a totalExportedEntries statistic to the outputted XML. This allows users to see the total number of exported buckets rather than just the difference. Secondly, this increments statTotalEntries for FlowHashTables when new buckets are created. Previously, this was not done for flow aggregators, only for packet aggregators.