### PR TITLE
Allow sensor statistics to be cleared

### DIFF
--- a/src/common/Sensor.h
+++ b/src/common/Sensor.h
@@ -15,6 +15,11 @@ public:
 	virtual ~Sensor();
 
 	/**
+	 * clears the statistics belonging to this module
+	 */
+	virtual void clearStatistics() {};
+
+	/**
 	 * @param time in seconds when this function was called last time (to be used for calculating average)
 	 * @returns a string containing statistics about the current module in XML format
 	 */

--- a/src/common/defs.h
+++ b/src/common/defs.h
@@ -38,6 +38,11 @@
 #define SM_DEFAULT_OUTPUT_FNAME "sensor_output.xml"
 
 /**
+ * default sensor manager's filename to check for the clear file
+ */
+#define SM_DEFAULT_CLEAR_FNAME "sensor_clear.txt"
+
+/**
  * default sensor manager's flag variable that determines, if
  * output file should be appended to or overwritten
  */

--- a/src/core/SensorManager.h
+++ b/src/core/SensorManager.h
@@ -21,7 +21,8 @@ public:
 	void stopSMThread();
 	void retrieveStatistics(bool ignoreshutdown = false);
 	void setGraphIS(GraphInstanceSupplier* gis);
-	void setParameters(uint32_t checkInterval, string outputfilename, bool append,
+	void setParameters(uint32_t checkInterval, string outputfilename,
+							 string clearfilename, bool append,
 							 GraphInstanceSupplier* gis);
 
 
@@ -42,10 +43,12 @@ private:
 	list<SensorEntry> sensors;
 	Mutex mutex; /** protects variable sensors */
 	ThreadCPUInterface::SystemInfo lastSystemInfo;
+	time_t lastClearTimestamp;
 
 	// config variables
 	uint32_t checkInterval; /** check interval in seconds */
 	string outputFilename;
+	string clearFilename;
 	time_t lasttime;
 	bool smExitFlag; /** own exit flag, as sensor manager thread should quit last */
 	char hostname[100];
@@ -54,6 +57,7 @@ private:
 	SensorManager();
 
 	static void* threadWrapper(void* instance);
+	bool checkClear();
 	void collectDataWorker();
 	void writeSensorXML(FILE* file, Sensor* s, const char* name, uint32_t id, bool module,
 			   			time_t curtime, time_t lasttime, vector<uint32_t>* nextids);

--- a/src/modules/SensorManagerCfg.cpp
+++ b/src/modules/SensorManagerCfg.cpp
@@ -30,6 +30,7 @@ SensorManagerCfg::SensorManagerCfg(XMLElement* elem)
 	: CfgHelper<SensorManager, SensorManagerCfg>(elem, "sensorManager", false),
 	  checkInterval(SM_DEFAULT_CHECK_INTERVAL),
 	  sensorOutput(SM_DEFAULT_OUTPUT_FNAME),
+	  clearFilename(SM_DEFAULT_CLEAR_FNAME),
 	  append(SM_DEFAULT_APPEND)
 {
 	if (!elem) return; // needed because of table inside ConfigManager
@@ -49,6 +50,11 @@ SensorManagerCfg::SensorManagerCfg(XMLElement* elem)
 			sensorOutput = e->getFirstText().c_str();
 			if (sensorOutput.size() == 0) {
 				THROWEXCEPTION("invalid sensor output file specified: '%s'", e->getFirstText().c_str());
+			}
+		} else if (e->matches("clearfilename")) {
+			clearFilename = e->getFirstText().c_str();
+			if (clearFilename.size() == 0) {
+				THROWEXCEPTION("invalid sensor clear file specified: '%s'", e->getFirstText().c_str());
 			}
 		} else if (e->matches("append")) {
 			append = getInt("append")>0;
@@ -76,7 +82,8 @@ SensorManager* SensorManagerCfg::createInstance()
 		//THROWEXCEPTION("multiple instances of module SensorManager must not be created");
 	}
 	instance = &SensorManager::getInstance();
-	instance->setParameters(checkInterval, sensorOutput, append, graphIS);
+	instance->setParameters(checkInterval, sensorOutput, clearFilename, append,
+							graphIS);
 	instanceCreated = true;
 	return instance;
 }

--- a/src/modules/SensorManagerCfg.h
+++ b/src/modules/SensorManagerCfg.h
@@ -55,6 +55,7 @@ private:
 	// config variables
 	uint32_t checkInterval; /** sensor check interval in seconds */
 	string sensorOutput; /** filename of output file which contains sensor data */
+	string clearFilename; /** filename of sensor clear file */
 	bool append;	/** append to output file or overwrite */
 };
 

--- a/src/modules/ipfix/IpfixSender.cpp
+++ b/src/modules/ipfix/IpfixSender.cpp
@@ -787,6 +787,13 @@ void IpfixSender::onReconfiguration1()
 {
 }
 
+void IpfixSender::clearStatistics()
+{
+	statSentDataRecords = 0;
+	statSentPackets = 0;
+	statPacketsInFlows = 0;
+}
+
 string IpfixSender::getStatisticsXML(double interval)
 {
 	char buf[200];

--- a/src/modules/ipfix/IpfixSender.hpp
+++ b/src/modules/ipfix/IpfixSender.hpp
@@ -69,7 +69,7 @@ public:
 	// inherited from Notifiable
 	virtual void onTimeout(void* dataPtr);
 
-
+	virtual void clearStatistics();
 	virtual string getStatisticsXML(double interval);
 	
 protected:

--- a/src/modules/ipfix/aggregator/BaseAggregator.cpp
+++ b/src/modules/ipfix/aggregator/BaseAggregator.cpp
@@ -220,6 +220,13 @@ void* BaseAggregator::threadWrapper(void* instance)
 	return 0;
 }
 
+void BaseAggregator::clearStatistics()
+{
+	for (size_t i = 0; i < rules->count; i++) {
+		rules->rule[i]->hashtable->clearStatistics();
+	}
+}
+
 string BaseAggregator::getStatisticsXML(double interval)
 {
 	ostringstream oss;

--- a/src/modules/ipfix/aggregator/BaseAggregator.h
+++ b/src/modules/ipfix/aggregator/BaseAggregator.h
@@ -43,6 +43,7 @@ public:
 	virtual void onReconfiguration1();
 	virtual void postReconfiguration();
 
+	virtual void clearStatistics();
 	virtual string getStatisticsXML(double interval);
 
 protected:

--- a/src/modules/ipfix/aggregator/BaseHashtable.cpp
+++ b/src/modules/ipfix/aggregator/BaseHashtable.cpp
@@ -479,6 +479,12 @@ void BaseHashtable::postReconfiguration()
 	sendDataTemplate();
 }
 
+void BaseHashtable::clearStatistics()
+{
+	statExportedBuckets = 0;
+	statLastExpBuckets = 0;
+}
+
 std::string BaseHashtable::getStatisticsXML(double interval)
 {
 	ostringstream oss;

--- a/src/modules/ipfix/aggregator/BaseHashtable.h
+++ b/src/modules/ipfix/aggregator/BaseHashtable.h
@@ -63,6 +63,7 @@ public:
 
 	virtual ~BaseHashtable();
 
+	virtual void clearStatistics();
 	virtual std::string getStatisticsXML(double interval);
 	void expireFlows(bool all = false);
 


### PR DESCRIPTION
This pull request provides the infrastructure to allow sensor statistics to be cleared. This works by checking the modification timestamp of a configurable clear file (by default "sensor_clear.txt") every time the sensor manager runs to collect statistics and dump them to an XML file. If the modification timestamp is later than the previous time we checked, then statistics are cleared by calling a `clearStatistics` method on each sensor.

The `clearStatistics` method is implemented as an empty method on the `Sensor` base class. This means that the method can be overridden in subclasses as required. This pull request contains concrete implementations of `clearStatistics` for the `IpfixSender`, `BaseAggregator` and `BaseHashTable` classes.