### PR TITLE
Add support for 16 bits tcp flags (new RFC) and add option to disable autoadd of address mask

### DIFF
--- a/src/core/InfoElementCfg.h
+++ b/src/core/InfoElementCfg.h
@@ -21,6 +21,8 @@ public:
 		ieName	         = getOptional("ieName");
 		modifier         = getOptional("modifier");
 		match            = getOptional("match");
+		autoAddV4PrefixLength = getBool("autoAddV4PrefixLength", true);
+
 
 		if (ieId>0) {
 			// check if ieID is known to Vermont
@@ -82,6 +84,8 @@ public:
 
 	bool isKnownIE() { return knownIE; }
 
+	bool getAutoAddV4PrefixLength() { return autoAddV4PrefixLength; }
+
 private:
 	std::string ieName;
 	uint16_t ieLength;
@@ -92,6 +96,7 @@ private:
 	std::string modifier;
 
 	bool knownIE;
+	bool autoAddV4PrefixLength;
 };
 
 #endif /*INFOELEMENTCFG_H_*/

--- a/src/modules/ipfix/Connection.h
+++ b/src/modules/ipfix/Connection.h
@@ -33,11 +33,30 @@ using namespace std;
 class Connection
 {
 	public:
-		static const uint8_t FIN = 0x01;
-		static const uint8_t SYN = 0x02;
-		static const uint8_t RST = 0x04;
-		static const uint8_t ACK = 0x10;
-
+		// static values in network order
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+		static const uint16_t FIN = 0x0001;
+		static const uint16_t SYN = 0x0002;
+		static const uint16_t RST = 0x0004;
+		static const uint16_t PSH = 0x0008;
+		static const uint16_t ACK = 0x0010;
+		static const uint16_t URG = 0x0020;
+		static const uint16_t ECE = 0x0040;
+		static const uint16_t CWR = 0x0080;
+		static const uint16_t NS  = 0x0100;
+		static const uint16_t MASK = 0x01ff; /**< mask reserved bits and size **/
+#else
+		static const uint16_t FIN = 0x0100;
+		static const uint16_t SYN = 0x0200;
+		static const uint16_t RST = 0x0400;
+		static const uint16_t PSH = 0x0800;
+		static const uint16_t ACK = 0x1000;
+		static const uint16_t URG = 0x2000;
+		static const uint16_t ECE = 0x4000;
+		static const uint16_t CWR = 0x8000;
+		static const uint16_t NS  = 0x0001;
+		static const uint16_t MASK = 0xff01; /**< mask reserved bits and size **/
+#endif
 		// ATTENTION: next four elements MUST be declared sequentially without another element interrupting it
 		// because hash and compare is performed by accessing the memory directly from srcIP on
 		// (see function calcHash and compareTo)
@@ -58,8 +77,8 @@ class Connection
 		uint64_t dstTransOctets; /**< host-byte order! **/
 		uint64_t srcPackets; /**< network-byte order! **/
 		uint64_t dstPackets; /**< network-byte order! **/
-		uint8_t srcTcpControlBits;
-		uint8_t dstTcpControlBits;
+		uint16_t srcTcpControlBits; /**< network-byte order! **/
+		uint16_t dstTcpControlBits; /**< network-byte order! **/
 		uint8_t protocol;
 		char* srcPayload;
 		uint32_t srcPayloadLen; /**< host-byte order! **/
@@ -80,7 +99,7 @@ class Connection
 		virtual ~Connection();
 		void addFlow(Connection* c);
 		string toString();
-		string printTcpControlBits(uint8_t bits);
+		string printTcpControlBits(uint16_t bits);
 		bool compareTo(Connection* c, bool to);
 		uint32_t getHash(bool to, uint32_t maxval);
 		void aggregate(Connection* c, uint32_t expireTime, bool to);

--- a/src/modules/ipfix/IpfixCsExporter.cpp
+++ b/src/modules/ipfix/IpfixCsExporter.cpp
@@ -183,8 +183,18 @@ void IpfixCsExporter::onDataRecord(IpfixDataRecord* record)
 	}
 
 	fi = record->templateInfo->getFieldInfo(IPFIX_TYPEID_tcpControlBits, 0);
-        if (fi != 0) {
-		csRecord->tcp_control_bits = *(uint8_t*)(record->data + fi->offset);
+	if (fi != 0) {
+		/*
+		 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+		 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+		 */
+		if (fi->type.length == 2) {
+			csRecord->tcp_control_bits = *(uint16_t*)(record->data + fi->offset) & Connection::MASK;
+		} else if (fi->type.length == 1) {
+			csRecord->tcp_control_bits = htons((uint16_t)*(uint8_t*)(record->data + fi->offset));
+		} else {
+			csRecord->tcp_control_bits = 0;
+		}
 	}
 
 	uint64_t timestart = retrieveTime(record, IPFIX_TYPEID_flowStartNanoseconds, IPFIX_TYPEID_flowStartMilliseconds,
@@ -230,7 +240,17 @@ void IpfixCsExporter::onDataRecord(IpfixDataRecord* record)
 
 	fi = record->templateInfo->getFieldInfo(IPFIX_TYPEID_tcpControlBits, IPFIX_PEN_reverse);
 	if (fi != 0) {
-		csRecord->rev_tcp_control_bits = *(uint8_t*)(record->data + fi->offset);
+		/*
+		 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+		 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+		 */
+		if (fi->type.length == 2) {
+			csRecord->rev_tcp_control_bits = *(uint16_t*)(record->data + fi->offset) & Connection::MASK;
+		} else if (fi->type.length == 1) {
+			csRecord->rev_tcp_control_bits = htons((uint16_t)*(uint8_t*)(record->data + fi->offset));
+		} else {
+			csRecord->rev_tcp_control_bits = 0;
+		}
 	}
 
 	//add data to linked list

--- a/src/modules/ipfix/IpfixCsExporter.hpp
+++ b/src/modules/ipfix/IpfixCsExporter.hpp
@@ -120,7 +120,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 			uint16_t destination_transport_port;    // encode udp/tcp ports here
 			uint8_t  icmp_type_ipv4;
 			uint8_t  icmp_code_ipv4;
-			uint8_t  tcp_control_bits;
+			uint16_t  tcp_control_bits;
 			uint64_t flow_start_milliseconds;       // encode flowStart(Micro|Nano|)Seconds here
 			uint64_t flow_end_milliseconds;         // encode flowEnd(Micro|Nano|)Seconds here
 			uint64_t octet_total_count;
@@ -128,7 +128,7 @@ class IpfixCsExporter : public Module, public Source<NullEmitable*>, public Ipfi
 			uint8_t  biflow_direction;
 			uint64_t rev_octet_total_count;
 			uint64_t rev_packet_total_count;
-			uint8_t  rev_tcp_control_bits;
+			uint16_t  rev_tcp_control_bits;
 		} DISABLE_ALIGNMENT
 
 		list<Ipfix_basic_flow*> chunkList;

--- a/src/modules/ipfix/IpfixNetflowExporter.cpp
+++ b/src/modules/ipfix/IpfixNetflowExporter.cpp
@@ -168,7 +168,8 @@ void IpfixNetflowExporter::sendPacket()
 			r->last = htonl(timediff.tv_sec*1000+timediff.tv_usec/1000);
 			r->srcport = c.srcPort;
 			r->dstport = c.dstPort;
-			r->tcp_flags = c.srcTcpControlBits;
+			// As per RFCs, lose NS bit and 3 "future use" bits
+			r->tcp_flags = (uint8_t)ntohs(c.srcTcpControlBits);
 			r->prot = c.protocol;
 			record->removeReference();
 			count++;

--- a/src/modules/ipfix/IpfixPayloadWriter.cpp
+++ b/src/modules/ipfix/IpfixPayloadWriter.cpp
@@ -79,7 +79,9 @@ void IpfixPayloadWriter::onDataRecord(IpfixDataRecord* record)
 
 	if (!ignoreEmptyPayload || conn->srcPayloadLen>0 || conn->dstPayloadLen>0) {
 		if (!ignoreIncompleteTCP || conn->protocol!=6 ||
-				((conn->srcTcpControlBits&2)==2 && ((conn->dstTcpControlBits&2)==2))) { // check if both directions have SYN flag set
+				((conn->srcTcpControlBits&Connection::SYN)==Connection::SYN &&
+						((conn->dstTcpControlBits&Connection::SYN)==Connection::SYN))) {
+			// check if both directions have SYN flag set
 			if (noConnections>0) {
 				// insert entry into sorted list
 				list<Connection*>::iterator iter = connections.begin();

--- a/src/modules/ipfix/IpfixSender.cpp
+++ b/src/modules/ipfix/IpfixSender.cpp
@@ -346,6 +346,11 @@ void IpfixSender::onTemplate(IpfixTemplateRecord* record)
 			ipfix_put_template_field(ipfixExporter, my_template_id, IPFIX_TYPEID_destinationIPv4Address, 4, 0);
 			ipfix_put_template_field(ipfixExporter, my_template_id, IPFIX_TYPEID_destinationIPv4PrefixLength, 1, 0);
 		}
+		else if ((export_protocol == NFV9_PROTOCOL) &&
+				(fi->type.id == IPFIX_TYPEID_tcpControlBits) &&
+				(fi->type.length != 1)) {
+			ipfix_put_template_field(ipfixExporter, my_template_id, IPFIX_TYPEID_tcpControlBits, 1, 0);
+		}
 		else {
 			ipfix_put_template_field(ipfixExporter, my_template_id, fi->type.id, fi->type.length, fi->type.enterprise);
 		}
@@ -367,6 +372,11 @@ void IpfixSender::onTemplate(IpfixTemplateRecord* record)
 		else if ((fi->type.id == IPFIX_TYPEID_destinationIPv4Address) && (fi->type.length == 5)) {
 			ipfix_put_template_fixedfield(ipfixExporter, my_template_id, IPFIX_TYPEID_destinationIPv4Address, 4, 0);
 			ipfix_put_template_fixedfield(ipfixExporter, my_template_id, IPFIX_TYPEID_destinationIPv4PrefixLength, 1, 0);
+		}
+		else if ((export_protocol == NFV9_PROTOCOL) &&
+				(fi->type.id == IPFIX_TYPEID_tcpControlBits) &&
+				(fi->type.length != 1)) {
+			ipfix_put_template_fixedfield(ipfixExporter, my_template_id, IPFIX_TYPEID_tcpControlBits, 1, 0);
 		}
 		else {
 			ipfix_put_template_fixedfield(ipfixExporter, my_template_id, fi->type.id, fi->type.length, fi->type.enterprise);
@@ -635,6 +645,12 @@ void IpfixSender::onDataRecord(IpfixDataRecord* record)
 			*mask = 32 - *(uint8_t*)(data + fi->offset + 4);
 			ipfix_put_data_field(ipfixExporter, data + fi->offset, 4);
 			ipfix_put_data_field(ipfixExporter, mask, 1);
+		}
+		else if ((export_protocol == NFV9_PROTOCOL) &&
+				(fi->type.id == IPFIX_TYPEID_tcpControlBits) &&
+				(fi->type.length != 1)) {
+			// data is in network order, we want just the second byte as per RFC
+			ipfix_put_data_field(ipfixExporter, data + fi->offset + 1, 1);
 		}
 		else {
 			if (fi->type.id == IPFIX_TYPEID_packetDeltaCount && fi->type.length<=8) {

--- a/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
+++ b/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
@@ -124,8 +124,9 @@ Rule::Field* AggregatorBaseCfg::readNonFlowKeyRule(XMLElement* e)
 	ruleField->type.enterprise = ie.getEnterpriseNumber();
 	ruleField->type.length = ie.getIeLength();
 
-	if ((ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_sourceIPv4Address, 0)) ||
-			(ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_destinationIPv4Address, 0))) {
+	if (ie.getAutoAddV4PrefixLength() &&
+			(ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_sourceIPv4Address, 0) ||
+			ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_destinationIPv4Address, 0))) {
 		ruleField->type.length++; // for additional mask field
 	}
 
@@ -161,7 +162,8 @@ Rule::Field* AggregatorBaseCfg::readFlowKeyRule(XMLElement* e) {
 		ruleField->type.enterprise = ie.getEnterpriseNumber();
 		ruleField->type.length = ie.getIeLength();
 
-		if ((ruleField->type.id == IPFIX_TYPEID_sourceIPv4Address) || (ruleField->type.id == IPFIX_TYPEID_destinationIPv4Address)) {
+		if (ie.getAutoAddV4PrefixLength() &&
+				(ruleField->type.id == IPFIX_TYPEID_sourceIPv4Address || ruleField->type.id == IPFIX_TYPEID_destinationIPv4Address)) {
 			ruleField->type.length++; // for additional mask field
 		}
 

--- a/src/modules/ipfix/aggregator/FlowHashtable.cpp
+++ b/src/modules/ipfix/aggregator/FlowHashtable.cpp
@@ -25,6 +25,7 @@
 #include "common/crc.hpp"
 #include "common/Misc.h"
 #include "modules/ipfix/IpfixPrinter.hpp"
+#include "modules/ipfix/Connection.h"
 
 
 
@@ -117,8 +118,17 @@ int FlowHashtable::aggregateField(TemplateInfo::FieldInfo* basefi, TemplateInfo:
 					return 0;
 
 				case IPFIX_TYPEID_tcpControlBits:
-					ASSERT(type->length==1, "unsupported length for type");
-					*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+					/*
+					 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+					 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+					 */
+					ASSERT(type->length==1 || type->length==2,
+							"unsupported length for type tcpControlBits");
+					if (type->length==1) {
+						*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+					} else {
+						*((uint16_t*)baseData) |= (*((uint16_t*)deltaData) & Connection::MASK);
+					}
 					return 0;
 			}
 			break;
@@ -176,8 +186,17 @@ int FlowHashtable::aggregateField(TemplateInfo::FieldInfo* basefi, TemplateInfo:
 					return 0;
 
 				case IPFIX_TYPEID_tcpControlBits:
-					ASSERT(type->length==1, "unsupported length for type");
-					*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+					/*
+					 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+					 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+					 */
+					ASSERT(type->length==1 || type->length==2,
+							"unsupported length for type tcpControlBits");
+					if (type->length==1) {
+						*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+					} else {
+						*((uint16_t*)baseData) |= (*((uint16_t*)deltaData) & Connection::MASK);
+					}
 					return 0;
 
 			}

--- a/src/modules/ipfix/aggregator/PacketHashtable.cpp
+++ b/src/modules/ipfix/aggregator/PacketHashtable.cpp
@@ -29,6 +29,7 @@
 #include "common/Misc.h"
 #include "common/Time.h"
 #include "HashtableBuckets.h"
+#include "modules/ipfix/Connection.h"
 
 using namespace InformationElement;
 
@@ -282,7 +283,6 @@ void (*PacketHashtable::getCopyDataFunction(const ExpFieldData* efd))(CopyFuncPa
 		case IPFIX_PEN_reverse:
 			switch (efd->typeId.id) {
 				case IPFIX_TYPEID_protocolIdentifier:
-				case IPFIX_TYPEID_tcpControlBits:
 				case IPFIX_TYPEID_ipClassOfService:
 					if (efd->dstLength != 1) {
 						THROWEXCEPTION("unsupported length %d for type %s", efd->dstLength, efd->typeId.toString().c_str());
@@ -338,6 +338,12 @@ void (*PacketHashtable::getCopyDataFunction(const ExpFieldData* efd))(CopyFuncPa
 				case IPFIX_TYPEID_bgpSourceAsNumber:
 				case IPFIX_TYPEID_bgpDestinationAsNumber:
 					if (efd->dstLength != 2) {
+						THROWEXCEPTION("unsupported length %d for type %s", efd->dstLength, efd->typeId.toString().c_str());
+					}
+					break;
+
+				case IPFIX_TYPEID_tcpControlBits:
+					if (efd->dstLength < 1 || efd->dstLength > 2) {
 						THROWEXCEPTION("unsupported length %d for type %s", efd->dstLength, efd->typeId.toString().c_str());
 					}
 					break;
@@ -448,7 +454,6 @@ uint8_t PacketHashtable::getRawPacketFieldLength(const IeInfo& type)
 	if (type.enterprise == 0 || type.enterprise == IPFIX_PEN_reverse) {
 		switch (type.id) {
 			case IPFIX_TYPEID_protocolIdentifier:
-			case IPFIX_TYPEID_tcpControlBits:
 			case IPFIX_TYPEID_packetDeltaCount:
 			case IPFIX_TYPEID_packetTotalCount:
 			case IPFIX_TYPEID_ipClassOfService:
@@ -480,6 +485,16 @@ uint8_t PacketHashtable::getRawPacketFieldLength(const IeInfo& type)
 			case IPFIX_TYPEID_bgpSourceAsNumber:
 			case IPFIX_TYPEID_bgpDestinationAsNumber:
 				return 0;
+
+			case IPFIX_TYPEID_tcpControlBits:
+				/*
+				 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+				 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+				 */
+				if (type.length < 1 || type.length > 2) {
+					THROWEXCEPTION("unsupported length %d for type %d", type.length, type.id);
+				}
+				return type.length;
 
 			default:
 				THROWEXCEPTION("PacketHashtable: unknown typeid %s, failed to determine raw packet field length", type.toString().c_str());
@@ -598,7 +613,13 @@ int32_t PacketHashtable::getRawPacketFieldOffset(const IeInfo& type, const Packe
 
 			case IPFIX_TYPEID_tcpControlBits:
 				if(p->ipProtocolType == Packet::TCP) {
-					return p->transportHeader + 13 - p->data.netHeader;
+					if (type.length == 1) {
+						return p->transportHeader + 13 - p->data.netHeader;
+					} else if (type.length == 2) {
+						return p->transportHeader + 12 - p->data.netHeader;
+					} else {
+						THROWEXCEPTION("unsupported length %d for type %d", type.length, type.id);
+					}
 				} else {
 					DPRINTFL(MSG_VDEBUG, "given id is %s, protocol is %d, but expected was %d", type.toString().c_str(), p->ipProtocolType, Packet::TCP);
 				}
@@ -1152,8 +1173,18 @@ void PacketHashtable::aggregateField(const ExpFieldData* efd, HashtableBucket* h
 						*(uint64_t*)baseData = htonll(ntohll(*(uint64_t*)baseData)+1);
 						break;
 
-					case IPFIX_TYPEID_tcpControlBits:  // 1 byte src and dst, bitwise-or flows
-						*(uint8_t*)baseData |= *(uint8_t*)deltaData;
+					case IPFIX_TYPEID_tcpControlBits:  // 1/2 byte src and dst, bitwise-or flows
+						/*
+						 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+						 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+						 */
+						ASSERT(efd->typeId.length == 1 || efd->typeId.length == 2,
+								"unsupported length for type tcpControlBits");
+						if (efd->typeId.length == 1) {
+							*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+						} else {
+							*((uint16_t*)baseData) |= (*((uint16_t*)deltaData) & Connection::MASK);
+						}
 						break;
 
 						// no other types needed, as this is only for raw field input
@@ -1217,8 +1248,18 @@ void PacketHashtable::aggregateField(const ExpFieldData* efd, HashtableBucket* h
 						*(uint64_t*)baseData = htonll(ntohll(*(uint64_t*)baseData)+1);
 						break;
 
-					case IPFIX_TYPEID_tcpControlBits: // 1 byte src and dst, bitwise-or flows
-						*(uint8_t*)baseData |= *(uint8_t*)deltaData;
+					case IPFIX_TYPEID_tcpControlBits:  // 1/2 byte src and dst, bitwise-or flows
+						/*
+						 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+						 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+						 */
+						ASSERT(efd->typeId.length==1 || efd->typeId.length==2,
+								"unsupported length for type tcpControlBits");
+						if (efd->typeId.length==1) {
+							*((uint8_t*)baseData) |= *((uint8_t*)deltaData);
+						} else {
+							*((uint16_t*)baseData) |= (*((uint16_t*)deltaData) & Connection::MASK);
+						}
 						break;
 
 					default:

--- a/src/modules/ipfix/aggregator/Rules.cpp
+++ b/src/modules/ipfix/aggregator/Rules.cpp
@@ -31,6 +31,7 @@
 #include "common/ipfixlolib/ipfix.h"
 
 #include "common/msg.h"
+#include "modules/ipfix/Connection.h"
 
 #define MAX_LINE_LEN 256
 
@@ -201,23 +202,26 @@ int parsePortPattern(char* s, IpfixRecord::Data** fdata, InformationElement::IeL
  * @return 0 if successful
  */
 int parseTcpFlags(char* s, IpfixRecord::Data** fdata, InformationElement::IeLength* length) {
-	uint8_t flags = 0;
+	uint16_t flags = 0;
 
 	char* p = s;
 	char* pair;
 
 	while ((pair = get_next_token(&p, ","))) {
-		if (strcmp(pair, "FIN") == 0) flags = flags | 0x01;
-		else if (strcmp(pair, "SYN") == 0) flags = flags | 0x02;
-		else if (strcmp(pair, "RST") == 0) flags = flags | 0x04;
-		else if (strcmp(pair, "PSH") == 0) flags = flags | 0x08;
-		else if (strcmp(pair, "ACK") == 0) flags = flags | 0x10;
-		else if (strcmp(pair, "URG") == 0) flags = flags | 0x20;
+		if (strcmp(pair, "FIN") == 0) flags = flags | Connection::FIN;
+		else if (strcmp(pair, "SYN") == 0) flags = flags | Connection::SYN;
+		else if (strcmp(pair, "RST") == 0) flags = flags | Connection::RST;
+		else if (strcmp(pair, "PSH") == 0) flags = flags | Connection::PSH;
+		else if (strcmp(pair, "ACK") == 0) flags = flags | Connection::ACK;
+		else if (strcmp(pair, "URG") == 0) flags = flags | Connection::URG;
+		else if (strcmp(pair, "ECE") == 0) flags = flags | Connection::ECE;
+		else if (strcmp(pair, "CWR") == 0) flags = flags | Connection::CWR;
+		else if (strcmp(pair, "NS") == 0) flags = flags | Connection::NS;
 		else return -1;
 	}
 
 
-	*length = 1;
+	*length = 2;
 	IpfixRecord::Data* fd = (IpfixRecord::Data*)malloc(*length);
 	fd[0] = flags;
 	*fdata = fd;

--- a/src/modules/packet/Template.cpp
+++ b/src/modules/packet/Template.cpp
@@ -151,7 +151,17 @@ bool Template::getFieldOffsetAndHeader(const IeInfo& ie, uint16_t *offset, uint1
 				*validPacketClass = PCLASS_TRN_TCP;
 				break;
 			case IPFIX_TYPEID_tcpControlBits:
-				*offset=13;
+				/*
+				 * RFC rfc7011 and rfc7012 changed the tcpControlBits size
+				 * from 1 byte to 2 bytes. Support both as the RFC mandates.
+				 */
+				if (ie.length == 1) {
+					*offset=13;
+				} else if (ie.length == 2) {
+					*offset=12;
+				} else {
+					THROWEXCEPTION("unsupported length %d for type %d", ie.length, ie.id);
+				}
 				*header=HEAD_TRANSPORT;
 				*validPacketClass = PCLASS_TRN_TCP;
 				break;


### PR DESCRIPTION
- Support 16 bits tcpControlFlags in the Ipfix Aggregator
  The new Ipfix RFCs (7011 and 7012, see
  http://www.iana.org/assignments/ipfix/ipfix.xhtml) have changed
  the size of the tcpControlFlags from 1 byte to 2 bytes.
  Some part of the code, like the ipfixlolib, already support it,
  but the Ipfix Aggregator asserts when the field is not 1 byte long.
  The RFC and IANA page specifically say that in case an exporter does
  not support the upper flags, then 1 byte should be exported. So, in
  Vermont, we have to support both cases in ingress. But internally, in
  the aggregator, store everything in 2 bytes format. So if there is no
  aggregator and an exporter sends 1 byte field, we export 1 byte. But
  if there is an aggregator, convert to 2 bytes.
- Add option to disable auto add v4 mask
  IPv4 address mask is always added, but in some cases this is
  undesirable, for example when the source already adds the field to
  the IPFIX report that is received by Vermont.
