### PR TITLE
Implement modules re-use on config reload

### DIFF
--- a/src/core/ConnectionQueue.h
+++ b/src/core/ConnectionQueue.h
@@ -120,6 +120,30 @@ public:
 		mutex.unlock();
 	}
 
+	/**
+	 * -> see Timer::removeTimeout for nonspecific description
+	 * ATTENTION: this function assumes, that it is usually called by this class's own
+	 * thread, as the thread in processLoop always calculates the time of next interruption
+	 * before it suspends and this function is not able to interrupt it
+	 */
+	virtual void removeTimeout(void* dataPtr = 0)
+	{
+		// check if we are running, because otherwise permant calls to this function could
+		// allocate our memory which is never freed
+		if (!Adapter<T>::running && !initPhase)
+			return;
+
+		mutex.lock();
+		list<TimeoutEntry*>::iterator iter = timeouts.begin();
+		while (iter != timeouts.end()) {
+			TimeoutEntry* te = *iter;
+			if (te->dataPtr == dataPtr)
+				iter = timeouts.erase(iter);
+			delete te;
+		}
+		mutex.unlock();
+	}
+
 
 private:
 	ConcurrentQueue<T> queue;  /**< contains all elements which were received from previous modules */

--- a/src/core/InfoElementCfg.h
+++ b/src/core/InfoElementCfg.h
@@ -86,6 +86,17 @@ public:
 
 	bool getAutoAddV4PrefixLength() { return autoAddV4PrefixLength; }
 
+	bool operator==(const InfoElementCfg &other) const {
+		if (other.ieLength != ieLength) return false;
+		if (other.ieId != ieId) return true;
+		if (other.enterpriseNumber != enterpriseNumber) return false;
+		if (other.ieName != ieName) return false;
+		if (other.modifier != modifier) return false;
+		if (other.match != match) return false;
+		if (other.autoAddV4PrefixLength != autoAddV4PrefixLength) return false;
+		return true;
+	}
+
 private:
 	std::string ieName;
 	uint16_t ieLength;

--- a/src/core/Timer.h
+++ b/src/core/Timer.h
@@ -42,6 +42,13 @@ public:
 	 *             Notifiable may distinguish between different timeouts
 	 */
 	virtual void addTimeout(Notifiable* n, struct timespec& ts, void* dataPtr = 0) = 0;
+
+	/**
+	 * Removes a timeout using the flag to identify it.
+	 * @param flag user-defined flag which is passed to Notifiable::onTimeout, so that
+	 *             Notifiable may distinguish between different timeouts
+	 */
+	virtual void removeTimeout(void* dataPtr = 0) = 0;
 };
 
 #endif /*TIMER_H_*/

--- a/src/modules/analysis/P2PDetector.cpp
+++ b/src/modules/analysis/P2PDetector.cpp
@@ -297,6 +297,7 @@ void P2PDetector::onTimeout(void* dataPtr)
 void P2PDetector::performShutdown()
 {
 	onTimeout(NULL);
+	timer->removeTimeout(NULL);
 }
 
 /**

--- a/src/modules/ipfix/CollectorCfg.h
+++ b/src/modules/ipfix/CollectorCfg.h
@@ -48,7 +48,7 @@ public:
 	std::string getName() { return "collector"; }
 
 	CollectorCfg(XMLElement* elem)
-		: protocol(UDP), port(0), mtu(0), zmqHighWaterMark(0),
+		: protocol(UDP), port(0), mtu(0), buffer(0), zmqHighWaterMark(0),
 		  zmqPollTimeout(ZMQ_POLL_TIMEOUT_DEFAULT)
 	{
 		uint16_t defaultPort = 4739;

--- a/src/modules/ipfix/IpfixCollectorCfg.cpp
+++ b/src/modules/ipfix/IpfixCollectorCfg.cpp
@@ -116,5 +116,25 @@ bool IpfixCollectorCfg::deriveFrom(IpfixCollectorCfg* old)
 	 * Invalid templates must be removed in preReconfigure2() and the new templates
 	 * must be transmited on preConnect()
 	 */
-	return false;   // FIXME: implement it, to gain performance increase in reconnect
+	return equalTo(old);
+}
+
+bool IpfixCollectorCfg::equalTo(IpfixCollectorCfg* other)
+{
+	if (certificateChainFile != other->certificateChainFile ||
+			privateKeyFile != other->privateKeyFile ||
+			caFile != other->caFile ||
+			caPath != other->caPath) {
+		return false;
+	}
+
+	if (udpTemplateLifetime != other->udpTemplateLifetime) {
+		return false;
+	}
+
+	if (!listener->equalTo(other->listener)) {
+		return false;
+	}
+
+	return true;
 }

--- a/src/modules/ipfix/IpfixCollectorCfg.h
+++ b/src/modules/ipfix/IpfixCollectorCfg.h
@@ -39,6 +39,8 @@ public:
 	
 	bool deriveFrom(IpfixCollectorCfg* old);
 	
+	bool equalTo(IpfixCollectorCfg* other);
+
 private:
 	CollectorCfg* listener;
 

--- a/src/modules/ipfix/IpfixCsExporter.cpp
+++ b/src/modules/ipfix/IpfixCsExporter.cpp
@@ -432,4 +432,6 @@ void IpfixCsExporter::performShutdown()
 		writeChunkList();
 		closeFile();
 	}
+
+	timer->removeTimeout(NULL);
 }

--- a/src/modules/ipfix/IpfixExporterCfg.cpp
+++ b/src/modules/ipfix/IpfixExporterCfg.cpp
@@ -191,6 +191,7 @@ bool IpfixExporterCfg::equalTo(IpfixExporterCfg* other)
 	if (dtlsMaxConnectionLifetime != other->dtlsMaxConnectionLifetime) return false;
 	if (templateRefreshTime != other->templateRefreshTime) return false;
 	/* if (templateRefreshRate != other->templateRefreshRate) return false; */ /* TODO */
+	if (export_protocol != other->export_protocol) return false;
 	if (collectors.size() != other->collectors.size()) return false;
 	std::vector<CollectorCfg*>::const_iterator iter = collectors.begin();
 	while (iter != collectors.end()) {

--- a/src/modules/ipfix/IpfixExporterCfg.cpp
+++ b/src/modules/ipfix/IpfixExporterCfg.cpp
@@ -180,6 +180,15 @@ bool IpfixExporterCfg::deriveFrom(IpfixExporterCfg* other)
 
 bool IpfixExporterCfg::equalTo(IpfixExporterCfg* other)
 {
+	if (sctpDataLifetime != other->sctpDataLifetime) return false;
+	if (sctpReconnectInterval != other->sctpReconnectInterval) return false;
+	if (recordRateLimit != other->recordRateLimit) return false;
+	if (observationDomainId != other->observationDomainId) return false;
+	if (certificateChainFile != other->certificateChainFile) return false;
+	if (privateKeyFile != other->privateKeyFile) return false;
+	if (caFile != other->caFile) return false;
+	if (caPath != other->caPath) return false;
+	if (dtlsMaxConnectionLifetime != other->dtlsMaxConnectionLifetime) return false;
 	if (templateRefreshTime != other->templateRefreshTime) return false;
 	/* if (templateRefreshRate != other->templateRefreshRate) return false; */ /* TODO */
 	if (collectors.size() != other->collectors.size()) return false;

--- a/src/modules/ipfix/IpfixNetflowExporter.cpp
+++ b/src/modules/ipfix/IpfixNetflowExporter.cpp
@@ -108,6 +108,7 @@ void IpfixNetflowExporter::performShutdown()
 {
 	sendRecords(true);
 	close(sockfd);
+	timer->removeTimeout(NULL);
 }
 
 /**

--- a/src/modules/ipfix/IpfixRecord.cpp
+++ b/src/modules/ipfix/IpfixRecord.cpp
@@ -174,6 +174,20 @@ namespace InformationElement {
 		return buffer;
 	}
 
+	bool operator==(const IeInfo &rhs, const IeInfo &lhs) {
+		return (rhs.id==lhs.id) && (rhs.enterprise==lhs.enterprise);
+	}
+
+	bool operator!=(const IeInfo &rhs, const IeInfo &lhs) {
+		return !(rhs == lhs);
+	}
+
+	bool operator<(const IeInfo &rhs, const IeInfo &lhs) {
+		if (rhs.enterprise < lhs.enterprise) return true;
+		if (rhs.id < lhs.id) return true;
+		return false;
+	}
+
 }
 
 

--- a/src/modules/ipfix/IpfixRecord.hpp
+++ b/src/modules/ipfix/IpfixRecord.hpp
@@ -65,15 +65,9 @@ namespace InformationElement {
 		{
 		}
 
-		bool operator==(const IeInfo &other) const {
-			return (id==other.id) && (enterprise==other.enterprise);
-		}
-
-		bool operator<(const IeInfo &other) const {
-			if (enterprise<other.enterprise) return true;
-			if (id<other.id) return true;
-			return false;
-		}
+		friend bool operator==(const IeInfo &rhs, const IeInfo &lhs);
+		friend bool operator!=(const IeInfo &rhs, const IeInfo &lhs);
+		friend bool operator<(const IeInfo &rhs, const IeInfo &lhs);
 
 
 		IeId id; 			/**< Information Element Id */

--- a/src/modules/ipfix/IpfixSender.cpp
+++ b/src/modules/ipfix/IpfixSender.cpp
@@ -798,6 +798,7 @@ void IpfixSender::performShutdown()
 {
 	// send remaining records first
 	sendRecords(IfNotEmpty);
+	timer->removeTimeout(&timeoutIpfixlolibBeat);
 }
 
 /**

--- a/src/modules/ipfix/NetflowV9ConverterCfg.cpp
+++ b/src/modules/ipfix/NetflowV9ConverterCfg.cpp
@@ -67,6 +67,9 @@ NetflowV9Converter* NetflowV9ConverterCfg::createInstance()
 
 bool NetflowV9ConverterCfg::deriveFrom(NetflowV9ConverterCfg* old)
 {
-    return false;
+    if (copyMode == old->copyMode && keepFlowSysUpTime == old->keepFlowSysUpTime)
+        return true;
+    else
+        return false;
 }
 

--- a/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
+++ b/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
@@ -226,3 +226,13 @@ Rule::Field* AggregatorBaseCfg::readFlowKeyRule(XMLElement* e) {
 
 	return ruleField;
 }
+
+bool AggregatorBaseCfg::equalTo(AggregatorBaseCfg *other) {
+	if (maxBufferTime != other->maxBufferTime) return false;
+	if (minBufferTime != other->minBufferTime) return false;
+	if (pollInterval != other->pollInterval) return false;
+	if (htableBits != other->htableBits) return false;
+	if (*rules != *other->rules) return false;
+
+	return true;
+}

--- a/src/modules/ipfix/aggregator/AggregatorBaseCfg.h
+++ b/src/modules/ipfix/aggregator/AggregatorBaseCfg.h
@@ -34,6 +34,7 @@ class AggregatorBaseCfg
 public:
 	AggregatorBaseCfg(XMLElement* elem);
 	virtual ~AggregatorBaseCfg();
+	bool equalTo(AggregatorBaseCfg *other);
 
 protected:
 	Rule* readRule(XMLElement* elem);

--- a/src/modules/ipfix/aggregator/IpfixAggregatorCfg.cpp
+++ b/src/modules/ipfix/aggregator/IpfixAggregatorCfg.cpp
@@ -51,6 +51,6 @@ IpfixAggregator* IpfixAggregatorCfg::createInstance()
 
 bool IpfixAggregatorCfg::deriveFrom(IpfixAggregatorCfg* old)
 {
-	return false;  // FIXME: implement it, to gain performance increase in reconnect
+	return equalTo(old);
 }
 

--- a/src/modules/ipfix/aggregator/Rule.cpp
+++ b/src/modules/ipfix/aggregator/Rule.cpp
@@ -516,3 +516,37 @@ int Rule::dataRecordMatches(IpfixDataRecord* record) {
 	/* all rule fields were matched */
 	return 1;
 }
+
+bool operator==(const Rule &rhs, const Rule &lhs) {
+	if (rhs.id != lhs.id) return false;
+	if (rhs.preceding != lhs.preceding) return false;
+	if (rhs.fieldCount != lhs.fieldCount) return false;
+	if (rhs.biflowAggregation != lhs.biflowAggregation) return false;
+	if (rhs.patternFieldsLen != lhs.patternFieldsLen) return false;
+
+	for (int i = 0; i < rhs.fieldCount; i++) {
+		if (*rhs.field[i] != *lhs.field[i]) return false;
+	}
+
+	for (uint16_t i = 0; i< rhs.patternFieldsLen; i++) {
+		if (*rhs.patternFields[i] != *lhs.patternFields[i]) return false;
+	}
+
+	return true;
+}
+
+bool operator!=(const Rule &rhs, const Rule &lhs) {
+	return !(lhs == rhs);
+}
+
+bool operator==(const Rule::Field &rhs, const Rule::Field &lhs) {
+	if (rhs.modifier != lhs.modifier) return false;
+	if (rhs.type != lhs.type) return false;
+	if (rhs.pattern == NULL && lhs.pattern == NULL) return true;
+	if (rhs.pattern == NULL || lhs.pattern == NULL) return false;
+	return (!memcmp(rhs.pattern, lhs.pattern, rhs.type.length));
+}
+
+bool operator!=(const Rule::Field &rhs, const Rule::Field &lhs) {
+	return !(lhs == rhs);
+}

--- a/src/modules/ipfix/aggregator/Rule.hpp
+++ b/src/modules/ipfix/aggregator/Rule.hpp
@@ -55,6 +55,9 @@ class Rule : private PrintHelpers {
 					free(pattern);
 				}
 
+				friend bool operator==(const Field &rhs, const Field &lhs);
+				friend bool operator!=(const Field &rhs, const Field &lhs);
+
 				/*
 				 * Rule::Field Modifier can be DISCARD (throw away this field), KEEP (keep this field), AGGREGATE (create one aggregate flow per different field value) or between MASK_START and MASK_END (to determine how many bits of the IP Address to keep)
 				 */
@@ -72,6 +75,8 @@ class Rule : private PrintHelpers {
 		void print();
 		bool ExptemplateDataMatches(const Packet* p);
 		int dataRecordMatches(IpfixDataRecord* record);
+		friend bool operator==(const Rule &rhs, const Rule &lhs);
+		friend bool operator!=(const Rule &rhs, const Rule &lhs);
 
 		uint16_t id;
 		uint16_t preceding;

--- a/src/modules/ipfix/aggregator/Rules.cpp
+++ b/src/modules/ipfix/aggregator/Rules.cpp
@@ -378,3 +378,16 @@ Rules::Rules(char* fname) {
 	delete currentRule;
 }
 
+bool operator==(const Rules &rhs, const Rules &lhs) {
+	if (rhs.count != lhs.count) return false;
+
+	for (size_t i = 0; i < rhs.count; i++) {
+		if (*rhs.rule[i] != *lhs.rule[i]) return false;
+	}
+
+	return true;
+}
+
+bool operator!=(const Rules &rhs, const Rules &lhs) {
+	return !(lhs == rhs);
+}

--- a/src/modules/ipfix/aggregator/Rules.hpp
+++ b/src/modules/ipfix/aggregator/Rules.hpp
@@ -38,6 +38,8 @@ class Rules {
 		Rules();
 		Rules(char* fname);
 		~Rules();
+		friend bool operator==(const Rules &rhs, const Rules &lhs);
+		friend bool operator!=(const Rules &rhs, const Rules &lhs);
 
 		size_t count;
 		Rule* rule[MAX_RULES];

--- a/src/modules/packet/PSAMPExporterModule.cpp
+++ b/src/modules/packet/PSAMPExporterModule.cpp
@@ -220,4 +220,5 @@ void PSAMPExporterModule::performStart()
 void PSAMPExporterModule::performShutdown()
 {
 	// we could destroy the template here
+	timer->removeTimeout((void *)timerFlag);
 }


### PR DESCRIPTION
When the configuration is reloaded, if a module config has not changed, they can be reused. This was not fully implemented, and these commits finish the work.