### PR TITLE
Support for exporting over a device (VRF)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ MARK_AS_ADVANCED(
 )
 
 include(CppcheckTargets)
+include(CheckSymbolExists)
+include(CheckIncludeFile)
 
 ### basic modules
 
@@ -170,6 +172,19 @@ OPTION(DISABLE_UDP_CONNECT "Do not run connect on UDP socket" OFF)
 IF (DISABLE_UDP_CONNECT)
 	ADD_DEFINITIONS(-DDISABLE_UDP_CONNECT)
 ENDIF (DISABLE_UDP_CONNECT)
+
+### SO_BINDTODEVICE (VRF) support
+
+OPTION(ENABLE_VRF "Enable support for binding sockets via SO_BINDTODEVICE (VRF). Warning: requires support in runtime kernel for SO_BINDTODEVICE and VRF !" OFF)
+IF (ENABLE_VRF)
+	CHECK_SYMBOL_EXISTS("SO_BINDTODEVICE" "sys/socket.h" SO_BINDTODEVICE_FOUND)
+	IF (SO_BINDTODEVICE_FOUND)
+		ADD_DEFINITIONS(-DENABLE_VRF)
+	ELSE (SO_BINDTODEVICE_FOUND)
+		MESSAGE(WARNING "SO_BINDTODEVICE not found in sys/socket.h, will not build with ENABLE_VRF. Check Linux Kernel's userspace headers (eg: linux-libc-dev)")
+	ENDIF (SO_BINDTODEVICE_FOUND)
+ENDIF (ENABLE_VRF)
+CHECK_INCLUDE_FILE("linux/if.h" LINUX_IF_H_FOUND)
 
 ### MongoDB
 

--- a/src/common/ipfixlolib/ipfixlolib.h
+++ b/src/common/ipfixlolib/ipfixlolib.h
@@ -124,6 +124,15 @@ See ipfixlolib.h for details on how to use this library.
 #include "common/openssl/OpenSSL.h"
 #endif
 
+#ifdef LINUX_IF_H_FOUND
+#include <linux/if.h>
+#endif
+#ifndef IFNAMSIZ
+#define IFNAMSIZ 16
+#endif
+/* Add enough space for formatting: [foo] log */
+#define VRF_LOG_LEN IFNAMSIZ + 4
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -593,6 +602,7 @@ typedef struct {
 				a connection reaches a certain age.*/
 	const char *peer_fqdn;
 #endif
+	char vrf_name[IFNAMSIZ];
 } ipfix_receiving_collector;
 
 /*
@@ -683,7 +693,7 @@ int ipfix_beat(ipfix_exporter *exporter);
 int ipfix_init_exporter(export_protocol_version export_protocol, uint32_t observation_domain_id, ipfix_exporter **exporter);
 int ipfix_deinit_exporter(ipfix_exporter **exporter_p);
 
-int ipfix_add_collector(ipfix_exporter *exporter, const char *coll_ip_addr, uint16_t coll_port, enum ipfix_transport_protocol proto, void *aux_config);
+int ipfix_add_collector(ipfix_exporter *exporter, const char *coll_ip_addr, uint16_t coll_port, enum ipfix_transport_protocol proto, void *aux_config, const char *vrf_name);
 int ipfix_remove_collector(ipfix_exporter *exporter, const char *coll_ip_addr, uint16_t coll_port);
 int ipfix_start_template(ipfix_exporter *exporter, uint16_t template_id,  uint16_t field_count);
 int ipfix_start_optionstemplate_set(ipfix_exporter *exporter, uint16_t template_id, uint16_t scope_length, uint16_t option_length);

--- a/src/modules/ipfix/IpfixExporterCfg.cpp
+++ b/src/modules/ipfix/IpfixExporterCfg.cpp
@@ -160,7 +160,8 @@ IpfixSender* IpfixExporterCfg::createInstance()
 		instance->addCollector(
 			p->getIpAddress().c_str(),
 			p->getPort(), p->getProtocol(),
-			aux_config);
+			aux_config,
+			p->getVrfName().c_str());
 	}
 
 	return instance;

--- a/src/modules/ipfix/IpfixFileWriter.cpp
+++ b/src/modules/ipfix/IpfixFileWriter.cpp
@@ -81,7 +81,7 @@ int IpfixFileWriter::addCollector(uint16_t observationDomainId, std::string file
 		 msg(MSG_ERROR, 
 		   "maximum filsize < maximum message length - this could lead to serious problems");
 
-	if(ipfix_add_collector(ex, my_filename.c_str(), maximumFilesize, DATAFILE, NULL) != 0) {
+	if(ipfix_add_collector(ex, my_filename.c_str(), maximumFilesize, DATAFILE, NULL, "") != 0) {
 		msg(MSG_FATAL, "IpfixFileWriter: ipfix_add_collector of %s failed", my_filename.c_str());
 		return -1;
 	}

--- a/src/modules/ipfix/IpfixSender.hpp
+++ b/src/modules/ipfix/IpfixSender.hpp
@@ -55,7 +55,8 @@ public:
 	virtual ~IpfixSender();
 
 	void addCollector(const char *ip, uint16_t port,
-			ipfix_transport_protocol proto, void *aux_config);
+			ipfix_transport_protocol proto, void *aux_config,
+			const char *vrf_name);
 	void flushPacket();
 
 	virtual void notifyQueueRunning();

--- a/src/modules/packet/PSAMPExporterCfg.cpp
+++ b/src/modules/packet/PSAMPExporterCfg.cpp
@@ -113,13 +113,20 @@ PSAMPExporterModule* PSAMPExporterCfg::createInstance()
 		msg(MSG_DIALOG, "Exporter: Configuration of templateRefreshRate/Time not yet supported.");
 	}
 	for (unsigned i = 0; i != collectors.size(); ++i) {
-		msg(MSG_DEBUG, "PsampExporter: adding collector %s://%s:%d",
+		char vrf_log[VRF_LOG_LEN] = "";
+		if (!collectors[i]->getVrfName().empty()) {
+			snprintf(vrf_log, VRF_LOG_LEN, "[%.*s] ", IFNAMSIZ, collectors[i]->getVrfName().c_str());
+		}
+		msg(MSG_DEBUG, "%sPsampExporter: adding collector %s://%s:%d on VRF %s",
+				vrf_log,
 				collectors[i]->getProtocol()==132?"SCTP":"UDP",
 				collectors[i]->getIpAddress().c_str(),
-				collectors[i]->getPort());
+				collectors[i]->getPort(),
+				collectors[i]->getVrfName().c_str());
 		instance->addCollector(collectors[i]->getIpAddress().c_str(),
 				collectors[i]->getPort(),
-				collectors[i]->getProtocol());
+				collectors[i]->getProtocol(),
+				collectors[i]->getVrfName().c_str());
 	}
 
 	return instance;

--- a/src/modules/packet/PSAMPExporterModule.cpp
+++ b/src/modules/packet/PSAMPExporterModule.cpp
@@ -173,10 +173,10 @@ void PSAMPExporterModule::flushPacketStream() {
 	startNewPacketStream();
 }
 
-bool PSAMPExporterModule::addCollector(const char *address, uint16_t port, ipfix_transport_protocol protocol)
+bool PSAMPExporterModule::addCollector(const char *address, uint16_t port, ipfix_transport_protocol protocol, const char *vrfName)
 {
 	DPRINTF("Adding %i://%s:%d", protocol, address, port);
-	return(ipfix_add_collector(exporter, address, port, protocol, NULL) == 0);
+	return(ipfix_add_collector(exporter, address, port, protocol, NULL, vrfName) == 0);
 }
 
 void PSAMPExporterModule::receive(Packet* p)

--- a/src/modules/packet/PSAMPExporterModule.h
+++ b/src/modules/packet/PSAMPExporterModule.h
@@ -65,7 +65,7 @@ public:
                 return true;
 	}
 
-        bool addCollector(const char *address, uint16_t port, ipfix_transport_protocol protocol);
+        bool addCollector(const char *address, uint16_t port, ipfix_transport_protocol protocol, const char *vrfName);
 
 private:
 

--- a/src/tests/ipfixlolib/example_code.cc
+++ b/src/tests/ipfixlolib/example_code.cc
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
 	 */
 	ipfix_aux_config_udp aux_config;
 	aux_config.mtu = 1500;
-	ret = ipfix_add_collector(my_exporter, collector_ip, collector_port, UDP, &aux_config);
+	ret = ipfix_add_collector(my_exporter, collector_ip, collector_port, UDP, &aux_config, "");
 	printf("ipfix_add_collector returned %i\n", ret);
 
 	/*

--- a/src/tests/ipfixlolib/example_code_2.c
+++ b/src/tests/ipfixlolib/example_code_2.c
@@ -94,10 +94,10 @@ int add_collector(ipfix_exporter *exporter) {
     } else if (myconfig.transport_protocol == DTLS_OVER_SCTP) {
 	aux_config = &acdos;
     }
-    /* The type of the last parameter to ipfix_add_collector() depends
+    /* The type of the 5th parameter to ipfix_add_collector() depends
      * on the transport protocol that has been chose. */
     if ((ret = ipfix_add_collector(exporter, myconfig.coll_ip4_addr,
-		    myconfig.coll_port, myconfig.transport_protocol, aux_config))) {
+		    myconfig.coll_port, myconfig.transport_protocol, aux_config, ""))) {
 	fprintf(stderr, "ipfix_add_collector() failed.\n");
 	return -1;
     }

--- a/src/tests/ipfixlolib/mtutest.c
+++ b/src/tests/ipfixlolib/mtutest.c
@@ -67,7 +67,7 @@ void add_udp_collector(ipfix_exporter *exporter) {
 	ipfix_aux_config_udp acu = {
 		.mtu = 0
 	};
-	if (ipfix_add_collector(exporter, COLLECTOR_IP_ADDRESS, 4739, UDP, &acu)) {
+	if (ipfix_add_collector(exporter, COLLECTOR_IP_ADDRESS, 4739, UDP, &acu, "")) {
 		fprintf(stderr, "ipfix_add_collector() failed.\n");
 		exit(1);
 	}
@@ -78,7 +78,7 @@ void add_dtls_over_udp_collector(ipfix_exporter *exporter) {
 		.udp = { .mtu = MTU},
 		.dtls = { .peer_fqdn = NULL}
 	};
-	if (ipfix_add_collector(exporter, COLLECTOR_IP_ADDRESS, 4740, DTLS_OVER_UDP, &acu)) {
+	if (ipfix_add_collector(exporter, COLLECTOR_IP_ADDRESS, 4740, DTLS_OVER_UDP, &acu, "")) {
 		fprintf(stderr, "ipfix_add_collector() failed.\n");
 		exit(1);
 	}

--- a/src/tests/ipfixlolib/template_generation.c
+++ b/src/tests/ipfixlolib/template_generation.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 			exit(-1);
 		}
 
-		ret=ipfix_add_collector(my_exporter, "127.0.0.1", 4711, UDP);
+		ret=ipfix_add_collector(my_exporter, "127.0.0.1", 4711, UDP, NULL, "");
 		if (ret != 0) {
 			fprintf(stderr, "ipfix_add_collector failed!\n");
 			exit(-1);

--- a/src/tests/ipfixlolib/test_everything.cc
+++ b/src/tests/ipfixlolib/test_everything.cc
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
 #ifdef SUPPORT_SCTP
 		case 'c':
 			// add SCTP collector
-			ret=ipfix_add_collector(my_exporter, "127.0.0.1", 1500, SCTP, NULL);
+			ret=ipfix_add_collector(my_exporter, "127.0.0.1", 1500, SCTP, NULL, "");
 			
 			if (ret != 0) {
 				fprintf(stderr, "ipfix_add_collector failed!\n");
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
 			// add UDP collector
 			ipfix_aux_config_udp aux_config;
 			aux_config.mtu = 1500;
-			ret=ipfix_add_collector(my_exporter, "127.0.0.1", 4711, UDP, &aux_config);
+			ret=ipfix_add_collector(my_exporter, "127.0.0.1", 4711, UDP, &aux_config, "");
 			if (ret != 0) {
 				fprintf(stderr, "ipfix_add_collector failed!\n");
 				exit(-1);


### PR DESCRIPTION
The Linux kernel in the past couple of years has gained support for
Virtual Routing and Forwarding:
https://www.kernel.org/doc/Documentation/networking/vrf.txt
The SO_BINDTODEVICE socket option can be used to specify a particular
VRF other than the default.
Add support in ipfixlolib and in the configuration for the exporters.

A very common request from customers is to make it explicit in the logs when a message applies to a particular VRF, to disambiguate for example when IP addresses are mentioned (the same IP can be in different VRFs). So most of the diff is about adding this feature to the relevant logs.