### PR TITLE
Fix CMake check for linux/if.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ IF (ENABLE_VRF)
 		MESSAGE(WARNING "SO_BINDTODEVICE not found in sys/socket.h, will not build with ENABLE_VRF. Check Linux Kernel's userspace headers (eg: linux-libc-dev)")
 	ENDIF (SO_BINDTODEVICE_FOUND)
 ENDIF (ENABLE_VRF)
-CHECK_INCLUDE_FILE("linux/if.h" LINUX_IF_H_FOUND)
+CHECK_INCLUDE_FILE("linux/if.h" LINUX_IF_H_FOUND "-include sys/socket.h")
 
 ### MongoDB
 


### PR DESCRIPTION
CMake not only checks if the header exists, but tries to include and
compile it, which fails with linux/if.h since it needs another header
which it does not include itself.
Manually include it as a CFLAG in the CHECK_INCLUDE_FILE call to fix
it.

@ogasser noticed a small mistake in the previous PR - nothing bad as the include is only used to get a definition that is available as a fallback, but worth fixing anyway.