### PR TITLE
Add basicList implementation

### DIFF
--- a/configs/basiclist.xml
+++ b/configs/basiclist.xml
@@ -1,0 +1,83 @@
+<ipfixConfig>
+	<observer id="1">
+                <interface>enp0s25</interface>
+                <pcap_filter>ip</pcap_filter>
+		<next>2</next>
+	</observer>
+
+	<packetQueue id="2">
+		<maxSize>10</maxSize>
+		<next>6</next>
+	</packetQueue>
+
+	<packetAggregator id="6">
+		<rule>
+			<templateId>998</templateId>
+			<flowKey>
+				<ieName>sourceIPv4Address</ieName>
+				<autoAddV4PrefixLength>false</autoAddV4PrefixLength>
+			</flowKey>
+			<flowKey>
+				<ieName>destinationIPv4Address</ieName>
+				<autoAddV4PrefixLength>false</autoAddV4PrefixLength>
+			</flowKey>
+			<flowKey>
+				<ieName>protocolIdentifier</ieName>
+			</flowKey>
+			<flowKey>
+				<ieName>sourceTransportPort</ieName>
+			</flowKey>
+			<flowKey>
+				<ieName>destinationTransportPort</ieName>
+			</flowKey>
+
+			<nonFlowKey>
+				<ieName>flowStartMilliSeconds</ieName>
+			</nonFlowKey>
+			<nonFlowKey>
+				<ieName>flowEndMilliSeconds</ieName>
+			</nonFlowKey>
+			<nonFlowKey>
+				<ieName>octetDeltaCount</ieName>
+			</nonFlowKey>
+			<nonFlowKey>
+				<ieName>packetDeltaCount</ieName>
+			</nonFlowKey>
+            <nonFlowKey>
+                <ieName>basicList</ieName>
+                <semantic>ordered</semantic>
+                <fieldIeName>totalLengthIPv4</fieldIeName>
+            </nonFlowKey>
+			<nonFlowKey>
+				<ieName>tcpControlBits</ieName>
+			</nonFlowKey>
+			<nonFlowKey>
+				<ieName>basicList</ieName>
+				<semantic>ordered</semantic>
+				<fieldIeName>tcpControlBits</fieldIeName>
+			</nonFlowKey>
+			<nonFlowKey>
+				<ieName>basicList</ieName>
+				<semantic>ordered</semantic>
+				<fieldIeName>destinationIPv4Address</fieldIeName>
+			</nonFlowKey>
+		</rule>
+		<expiration>
+			<inactiveTimeout unit="sec">5</inactiveTimeout>
+			<activeTimeout unit="sec">5</activeTimeout>
+		</expiration>
+		<pollInterval unit="msec">1000</pollInterval>
+        <next>9</next>
+	</packetAggregator>
+
+	<ipfixExporter id="8">
+		<collector>
+			<ipAddress>127.0.0.1</ipAddress>
+			<transportProtocol>17</transportProtocol>
+			<port>1500</port>
+		</collector>
+	</ipfixExporter>
+
+    <ipfixPrinter id="9">
+	</ipfixPrinter>
+</ipfixConfig>

--- a/src/common/ipfixlolib/ipfix_iana.c
+++ b/src/common/ipfixlolib/ipfix_iana.c
@@ -432,6 +432,18 @@ struct ipfix_identifier ipfixids_iana[] = {
   { IPFIX_TYPEID_httpReasonPhrase                        , IPFIX_BYTES_string              ,     0, "httpReasonPhrase"                      , IPFIX_DATA_TYPE_httpReasonPhrase                         },
 };
 
+
+
+struct ipfix_semantic ipfixsemantic_iana[] = {
+/* IANA registry */
+  { IPFIX_STRUCTURED_TYPE_SEMANTIC_noneOf                        , "noneOf"   },
+  { IPFIX_STRUCTURED_TYPE_SEMANTIC_exactlyOneOf                  , "exactlyOneOf" },
+  { IPFIX_STRUCTURED_TYPE_SEMANTIC_oneOrMoreOf                   , "oneOrMoreOf" },
+  { IPFIX_STRUCTURED_TYPE_SEMANTIC_allOf                         , "allOf"    },
+  { IPFIX_STRUCTURED_TYPE_SEMANTIC_ordered                       , "ordered"  },
+  { IPFIX_STRUCTURED_TYPE_SEMANTIC_undefined                     , "undefined" },
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/ipfixlolib/ipfix_iana.c
+++ b/src/common/ipfixlolib/ipfix_iana.c
@@ -1,23 +1,3 @@
-/*
- * IPFIX Information Elements registered by IANA
- * Copyright (C) 2014 Oliver Gasser
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
- */
-
 #include "ipfix_iana.h"
 
 #ifdef __cplusplus
@@ -259,7 +239,7 @@ struct ipfix_identifier ipfixids_iana[] = {
   { IPFIX_TYPEID_exporterCertificate                     , IPFIX_BYTES_octetArray          ,     0, "exporterCertificate"                   , IPFIX_DATA_TYPE_exporterCertificate                      },
   { IPFIX_TYPEID_dataRecordsReliability                  , IPFIX_BYTES_boolean             ,     0, "dataRecordsReliability"                , IPFIX_DATA_TYPE_dataRecordsReliability                   },
   { IPFIX_TYPEID_observationPointType                    , IPFIX_BYTES_unsigned8           ,     0, "observationPointType"                  , IPFIX_DATA_TYPE_observationPointType                     },
-  { IPFIX_TYPEID_connectionCountNew                      , IPFIX_BYTES_unsigned32          ,     0, "connectionCountNew"                    , IPFIX_DATA_TYPE_connectionCountNew                       },
+  { IPFIX_TYPEID_newConnectionDeltaCount                 , IPFIX_BYTES_unsigned32          ,     0, "newConnectionDeltaCount"               , IPFIX_DATA_TYPE_newConnectionDeltaCount                  },
   { IPFIX_TYPEID_connectionSumDurationSeconds            , IPFIX_BYTES_unsigned64          ,     0, "connectionSumDurationSeconds"          , IPFIX_DATA_TYPE_connectionSumDurationSeconds             },
   { IPFIX_TYPEID_connectionTransactionId                 , IPFIX_BYTES_unsigned64          ,     0, "connectionTransactionId"               , IPFIX_DATA_TYPE_connectionTransactionId                  },
   { IPFIX_TYPEID_postNATSourceIPv6Address                , IPFIX_BYTES_ipv6Address         ,     0, "postNATSourceIPv6Address"              , IPFIX_DATA_TYPE_postNATSourceIPv6Address                 },
@@ -413,6 +393,43 @@ struct ipfix_identifier ipfixids_iana[] = {
   { IPFIX_TYPEID_layer2FrameTotalCount                   , IPFIX_BYTES_unsigned64          ,     0, "layer2FrameTotalCount"                 , IPFIX_DATA_TYPE_layer2FrameTotalCount                    },
   { IPFIX_TYPEID_pseudoWireDestinationIPv4Address        , IPFIX_BYTES_ipv4Address         ,     0, "pseudoWireDestinationIPv4Address"      , IPFIX_DATA_TYPE_pseudoWireDestinationIPv4Address         },
   { IPFIX_TYPEID_ignoredLayer2FrameTotalCount            , IPFIX_BYTES_unsigned64          ,     0, "ignoredLayer2FrameTotalCount"          , IPFIX_DATA_TYPE_ignoredLayer2FrameTotalCount             },
+  { IPFIX_TYPEID_mibObjectValueInteger                   , IPFIX_BYTES_signed32            ,     0, "mibObjectValueInteger"                 , IPFIX_DATA_TYPE_mibObjectValueInteger                    },
+  { IPFIX_TYPEID_mibObjectValueOctetString               , IPFIX_BYTES_octetArray          ,     0, "mibObjectValueOctetString"             , IPFIX_DATA_TYPE_mibObjectValueOctetString                },
+  { IPFIX_TYPEID_mibObjectValueOID                       , IPFIX_BYTES_octetArray          ,     0, "mibObjectValueOID"                     , IPFIX_DATA_TYPE_mibObjectValueOID                        },
+  { IPFIX_TYPEID_mibObjectValueBits                      , IPFIX_BYTES_octetArray          ,     0, "mibObjectValueBits"                    , IPFIX_DATA_TYPE_mibObjectValueBits                       },
+  { IPFIX_TYPEID_mibObjectValueIPAddress                 , IPFIX_BYTES_ipv4Address         ,     0, "mibObjectValueIPAddress"               , IPFIX_DATA_TYPE_mibObjectValueIPAddress                  },
+  { IPFIX_TYPEID_mibObjectValueCounter                   , IPFIX_BYTES_unsigned64          ,     0, "mibObjectValueCounter"                 , IPFIX_DATA_TYPE_mibObjectValueCounter                    },
+  { IPFIX_TYPEID_mibObjectValueGauge                     , IPFIX_BYTES_unsigned32          ,     0, "mibObjectValueGauge"                   , IPFIX_DATA_TYPE_mibObjectValueGauge                      },
+  { IPFIX_TYPEID_mibObjectValueTimeTicks                 , IPFIX_BYTES_unsigned32          ,     0, "mibObjectValueTimeTicks"               , IPFIX_DATA_TYPE_mibObjectValueTimeTicks                  },
+  { IPFIX_TYPEID_mibObjectValueUnsigned                  , IPFIX_BYTES_unsigned32          ,     0, "mibObjectValueUnsigned"                , IPFIX_DATA_TYPE_mibObjectValueUnsigned                   },
+  { IPFIX_TYPEID_mibObjectValueTable                     , IPFIX_BYTES_subTemplateList     ,     0, "mibObjectValueTable"                   , IPFIX_DATA_TYPE_mibObjectValueTable                      },
+  { IPFIX_TYPEID_mibObjectValueRow                       , IPFIX_BYTES_subTemplateList     ,     0, "mibObjectValueRow"                     , IPFIX_DATA_TYPE_mibObjectValueRow                        },
+  { IPFIX_TYPEID_mibObjectIdentifier                     , IPFIX_BYTES_octetArray          ,     0, "mibObjectIdentifier"                   , IPFIX_DATA_TYPE_mibObjectIdentifier                      },
+  { IPFIX_TYPEID_mibSubIdentifier                        , IPFIX_BYTES_unsigned32          ,     0, "mibSubIdentifier"                      , IPFIX_DATA_TYPE_mibSubIdentifier                         },
+  { IPFIX_TYPEID_mibIndexIndicator                       , IPFIX_BYTES_unsigned64          ,     0, "mibIndexIndicator"                     , IPFIX_DATA_TYPE_mibIndexIndicator                        },
+  { IPFIX_TYPEID_mibCaptureTimeSemantics                 , IPFIX_BYTES_unsigned8           ,     0, "mibCaptureTimeSemantics"               , IPFIX_DATA_TYPE_mibCaptureTimeSemantics                  },
+  { IPFIX_TYPEID_mibContextEngineID                      , IPFIX_BYTES_octetArray          ,     0, "mibContextEngineID"                    , IPFIX_DATA_TYPE_mibContextEngineID                       },
+  { IPFIX_TYPEID_mibContextName                          , IPFIX_BYTES_string              ,     0, "mibContextName"                        , IPFIX_DATA_TYPE_mibContextName                           },
+  { IPFIX_TYPEID_mibObjectName                           , IPFIX_BYTES_string              ,     0, "mibObjectName"                         , IPFIX_DATA_TYPE_mibObjectName                            },
+  { IPFIX_TYPEID_mibObjectDescription                    , IPFIX_BYTES_string              ,     0, "mibObjectDescription"                  , IPFIX_DATA_TYPE_mibObjectDescription                     },
+  { IPFIX_TYPEID_mibObjectSyntax                         , IPFIX_BYTES_string              ,     0, "mibObjectSyntax"                       , IPFIX_DATA_TYPE_mibObjectSyntax                          },
+  { IPFIX_TYPEID_mibModuleName                           , IPFIX_BYTES_string              ,     0, "mibModuleName"                         , IPFIX_DATA_TYPE_mibModuleName                            },
+  { IPFIX_TYPEID_mobileIMSI                              , IPFIX_BYTES_string              ,     0, "mobileIMSI"                            , IPFIX_DATA_TYPE_mobileIMSI                               },
+  { IPFIX_TYPEID_mobileMSISDN                            , IPFIX_BYTES_string              ,     0, "mobileMSISDN"                          , IPFIX_DATA_TYPE_mobileMSISDN                             },
+  { IPFIX_TYPEID_httpStatusCode                          , IPFIX_BYTES_unsigned16          ,     0, "httpStatusCode"                        , IPFIX_DATA_TYPE_httpStatusCode                           },
+  { IPFIX_TYPEID_sourceTransportPortsLimit               , IPFIX_BYTES_unsigned16          ,     0, "sourceTransportPortsLimit"             , IPFIX_DATA_TYPE_sourceTransportPortsLimit                },
+  { IPFIX_TYPEID_httpRequestMethod                       , IPFIX_BYTES_string              ,     0, "httpRequestMethod"                     , IPFIX_DATA_TYPE_httpRequestMethod                        },
+  { IPFIX_TYPEID_httpRequestHost                         , IPFIX_BYTES_string              ,     0, "httpRequestHost"                       , IPFIX_DATA_TYPE_httpRequestHost                          },
+  { IPFIX_TYPEID_httpRequestTarget                       , IPFIX_BYTES_string              ,     0, "httpRequestTarget"                     , IPFIX_DATA_TYPE_httpRequestTarget                        },
+  { IPFIX_TYPEID_httpMessageVersion                      , IPFIX_BYTES_string              ,     0, "httpMessageVersion"                    , IPFIX_DATA_TYPE_httpMessageVersion                       },
+  { IPFIX_TYPEID_natInstanceID                           , IPFIX_BYTES_unsigned32          ,     0, "natInstanceID"                         , IPFIX_DATA_TYPE_natInstanceID                            },
+  { IPFIX_TYPEID_internalAddressRealm                    , IPFIX_BYTES_octetArray          ,     0, "internalAddressRealm"                  , IPFIX_DATA_TYPE_internalAddressRealm                     },
+  { IPFIX_TYPEID_externalAddressRealm                    , IPFIX_BYTES_octetArray          ,     0, "externalAddressRealm"                  , IPFIX_DATA_TYPE_externalAddressRealm                     },
+  { IPFIX_TYPEID_natQuotaExceededEvent                   , IPFIX_BYTES_unsigned32          ,     0, "natQuotaExceededEvent"                 , IPFIX_DATA_TYPE_natQuotaExceededEvent                    },
+  { IPFIX_TYPEID_natThresholdEvent                       , IPFIX_BYTES_unsigned32          ,     0, "natThresholdEvent"                     , IPFIX_DATA_TYPE_natThresholdEvent                        },
+  { IPFIX_TYPEID_httpUserAgent                           , IPFIX_BYTES_string              ,     0, "httpUserAgent"                         , IPFIX_DATA_TYPE_httpUserAgent                            },
+  { IPFIX_TYPEID_httpContentType                         , IPFIX_BYTES_string              ,     0, "httpContentType"                       , IPFIX_DATA_TYPE_httpContentType                          },
+  { IPFIX_TYPEID_httpReasonPhrase                        , IPFIX_BYTES_string              ,     0, "httpReasonPhrase"                      , IPFIX_DATA_TYPE_httpReasonPhrase                         },
 };
 
 #ifdef __cplusplus

--- a/src/common/ipfixlolib/ipfix_iana.h
+++ b/src/common/ipfixlolib/ipfix_iana.h
@@ -1,23 +1,3 @@
-/*
- * IPFIX Information Elements registered by IANA
- * Copyright (C) 2014 Oliver Gasser
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
- */
-
 #ifndef IPFIX_IANA_H
 #define IPFIX_IANA_H
 
@@ -304,7 +284,7 @@
 #define IPFIX_TYPEID_exporterCertificate                      275
 #define IPFIX_TYPEID_dataRecordsReliability                   276
 #define IPFIX_TYPEID_observationPointType                     277
-#define IPFIX_TYPEID_connectionCountNew                       278
+#define IPFIX_TYPEID_newConnectionDeltaCount                  278
 #define IPFIX_TYPEID_connectionSumDurationSeconds             279
 #define IPFIX_TYPEID_connectionTransactionId                  280
 #define IPFIX_TYPEID_postNATSourceIPv6Address                 281
@@ -458,6 +438,43 @@
 #define IPFIX_TYPEID_layer2FrameTotalCount                    431
 #define IPFIX_TYPEID_pseudoWireDestinationIPv4Address         432
 #define IPFIX_TYPEID_ignoredLayer2FrameTotalCount             433
+#define IPFIX_TYPEID_mibObjectValueInteger                    434
+#define IPFIX_TYPEID_mibObjectValueOctetString                435
+#define IPFIX_TYPEID_mibObjectValueOID                        436
+#define IPFIX_TYPEID_mibObjectValueBits                       437
+#define IPFIX_TYPEID_mibObjectValueIPAddress                  438
+#define IPFIX_TYPEID_mibObjectValueCounter                    439
+#define IPFIX_TYPEID_mibObjectValueGauge                      440
+#define IPFIX_TYPEID_mibObjectValueTimeTicks                  441
+#define IPFIX_TYPEID_mibObjectValueUnsigned                   442
+#define IPFIX_TYPEID_mibObjectValueTable                      443
+#define IPFIX_TYPEID_mibObjectValueRow                        444
+#define IPFIX_TYPEID_mibObjectIdentifier                      445
+#define IPFIX_TYPEID_mibSubIdentifier                         446
+#define IPFIX_TYPEID_mibIndexIndicator                        447
+#define IPFIX_TYPEID_mibCaptureTimeSemantics                  448
+#define IPFIX_TYPEID_mibContextEngineID                       449
+#define IPFIX_TYPEID_mibContextName                           450
+#define IPFIX_TYPEID_mibObjectName                            451
+#define IPFIX_TYPEID_mibObjectDescription                     452
+#define IPFIX_TYPEID_mibObjectSyntax                          453
+#define IPFIX_TYPEID_mibModuleName                            454
+#define IPFIX_TYPEID_mobileIMSI                               455
+#define IPFIX_TYPEID_mobileMSISDN                             456
+#define IPFIX_TYPEID_httpStatusCode                           457
+#define IPFIX_TYPEID_sourceTransportPortsLimit                458
+#define IPFIX_TYPEID_httpRequestMethod                        459
+#define IPFIX_TYPEID_httpRequestHost                          460
+#define IPFIX_TYPEID_httpRequestTarget                        461
+#define IPFIX_TYPEID_httpMessageVersion                       462
+#define IPFIX_TYPEID_natInstanceID                            463
+#define IPFIX_TYPEID_internalAddressRealm                     464
+#define IPFIX_TYPEID_externalAddressRealm                     465
+#define IPFIX_TYPEID_natQuotaExceededEvent                    466
+#define IPFIX_TYPEID_natThresholdEvent                        467
+#define IPFIX_TYPEID_httpUserAgent                            468
+#define IPFIX_TYPEID_httpContentType                          469
+#define IPFIX_TYPEID_httpReasonPhrase                         470
 
 #define IPFIX_LENGTH_octetDeltaCount                          IPFIX_BYTES_unsigned64
 #define IPFIX_LENGTH_packetDeltaCount                         IPFIX_BYTES_unsigned64
@@ -692,7 +709,7 @@
 #define IPFIX_LENGTH_exporterCertificate                      IPFIX_BYTES_octetArray
 #define IPFIX_LENGTH_dataRecordsReliability                   IPFIX_BYTES_boolean
 #define IPFIX_LENGTH_observationPointType                     IPFIX_BYTES_unsigned8
-#define IPFIX_LENGTH_connectionCountNew                       IPFIX_BYTES_unsigned32
+#define IPFIX_LENGTH_newConnectionDeltaCount                  IPFIX_BYTES_unsigned32
 #define IPFIX_LENGTH_connectionSumDurationSeconds             IPFIX_BYTES_unsigned64
 #define IPFIX_LENGTH_connectionTransactionId                  IPFIX_BYTES_unsigned64
 #define IPFIX_LENGTH_postNATSourceIPv6Address                 IPFIX_BYTES_ipv6Address
@@ -846,6 +863,43 @@
 #define IPFIX_LENGTH_layer2FrameTotalCount                    IPFIX_BYTES_unsigned64
 #define IPFIX_LENGTH_pseudoWireDestinationIPv4Address         IPFIX_BYTES_ipv4Address
 #define IPFIX_LENGTH_ignoredLayer2FrameTotalCount             IPFIX_BYTES_unsigned64
+#define IPFIX_LENGTH_mibObjectValueInteger                    IPFIX_BYTES_signed32
+#define IPFIX_LENGTH_mibObjectValueOctetString                IPFIX_BYTES_octetArray
+#define IPFIX_LENGTH_mibObjectValueOID                        IPFIX_BYTES_octetArray
+#define IPFIX_LENGTH_mibObjectValueBits                       IPFIX_BYTES_octetArray
+#define IPFIX_LENGTH_mibObjectValueIPAddress                  IPFIX_BYTES_ipv4Address
+#define IPFIX_LENGTH_mibObjectValueCounter                    IPFIX_BYTES_unsigned64
+#define IPFIX_LENGTH_mibObjectValueGauge                      IPFIX_BYTES_unsigned32
+#define IPFIX_LENGTH_mibObjectValueTimeTicks                  IPFIX_BYTES_unsigned32
+#define IPFIX_LENGTH_mibObjectValueUnsigned                   IPFIX_BYTES_unsigned32
+#define IPFIX_LENGTH_mibObjectValueTable                      IPFIX_BYTES_subTemplateList
+#define IPFIX_LENGTH_mibObjectValueRow                        IPFIX_BYTES_subTemplateList
+#define IPFIX_LENGTH_mibObjectIdentifier                      IPFIX_BYTES_octetArray
+#define IPFIX_LENGTH_mibSubIdentifier                         IPFIX_BYTES_unsigned32
+#define IPFIX_LENGTH_mibIndexIndicator                        IPFIX_BYTES_unsigned64
+#define IPFIX_LENGTH_mibCaptureTimeSemantics                  IPFIX_BYTES_unsigned8
+#define IPFIX_LENGTH_mibContextEngineID                       IPFIX_BYTES_octetArray
+#define IPFIX_LENGTH_mibContextName                           IPFIX_BYTES_string
+#define IPFIX_LENGTH_mibObjectName                            IPFIX_BYTES_string
+#define IPFIX_LENGTH_mibObjectDescription                     IPFIX_BYTES_string
+#define IPFIX_LENGTH_mibObjectSyntax                          IPFIX_BYTES_string
+#define IPFIX_LENGTH_mibModuleName                            IPFIX_BYTES_string
+#define IPFIX_LENGTH_mobileIMSI                               IPFIX_BYTES_string
+#define IPFIX_LENGTH_mobileMSISDN                             IPFIX_BYTES_string
+#define IPFIX_LENGTH_httpStatusCode                           IPFIX_BYTES_unsigned16
+#define IPFIX_LENGTH_sourceTransportPortsLimit                IPFIX_BYTES_unsigned16
+#define IPFIX_LENGTH_httpRequestMethod                        IPFIX_BYTES_string
+#define IPFIX_LENGTH_httpRequestHost                          IPFIX_BYTES_string
+#define IPFIX_LENGTH_httpRequestTarget                        IPFIX_BYTES_string
+#define IPFIX_LENGTH_httpMessageVersion                       IPFIX_BYTES_string
+#define IPFIX_LENGTH_natInstanceID                            IPFIX_BYTES_unsigned32
+#define IPFIX_LENGTH_internalAddressRealm                     IPFIX_BYTES_octetArray
+#define IPFIX_LENGTH_externalAddressRealm                     IPFIX_BYTES_octetArray
+#define IPFIX_LENGTH_natQuotaExceededEvent                    IPFIX_BYTES_unsigned32
+#define IPFIX_LENGTH_natThresholdEvent                        IPFIX_BYTES_unsigned32
+#define IPFIX_LENGTH_httpUserAgent                            IPFIX_BYTES_string
+#define IPFIX_LENGTH_httpContentType                          IPFIX_BYTES_string
+#define IPFIX_LENGTH_httpReasonPhrase                         IPFIX_BYTES_string
 
 #define IPFIX_DATA_TYPE_octetDeltaCount                          IPFIX_TYPE_unsigned64
 #define IPFIX_DATA_TYPE_packetDeltaCount                         IPFIX_TYPE_unsigned64
@@ -1080,7 +1134,7 @@
 #define IPFIX_DATA_TYPE_exporterCertificate                      IPFIX_TYPE_octetArray
 #define IPFIX_DATA_TYPE_dataRecordsReliability                   IPFIX_TYPE_boolean
 #define IPFIX_DATA_TYPE_observationPointType                     IPFIX_TYPE_unsigned8
-#define IPFIX_DATA_TYPE_connectionCountNew                       IPFIX_TYPE_unsigned32
+#define IPFIX_DATA_TYPE_newConnectionDeltaCount                  IPFIX_TYPE_unsigned32
 #define IPFIX_DATA_TYPE_connectionSumDurationSeconds             IPFIX_TYPE_unsigned64
 #define IPFIX_DATA_TYPE_connectionTransactionId                  IPFIX_TYPE_unsigned64
 #define IPFIX_DATA_TYPE_postNATSourceIPv6Address                 IPFIX_TYPE_ipv6Address
@@ -1234,6 +1288,50 @@
 #define IPFIX_DATA_TYPE_layer2FrameTotalCount                    IPFIX_TYPE_unsigned64
 #define IPFIX_DATA_TYPE_pseudoWireDestinationIPv4Address         IPFIX_TYPE_ipv4Address
 #define IPFIX_DATA_TYPE_ignoredLayer2FrameTotalCount             IPFIX_TYPE_unsigned64
+#define IPFIX_DATA_TYPE_mibObjectValueInteger                    IPFIX_TYPE_signed32
+#define IPFIX_DATA_TYPE_mibObjectValueOctetString                IPFIX_TYPE_octetArray
+#define IPFIX_DATA_TYPE_mibObjectValueOID                        IPFIX_TYPE_octetArray
+#define IPFIX_DATA_TYPE_mibObjectValueBits                       IPFIX_TYPE_octetArray
+#define IPFIX_DATA_TYPE_mibObjectValueIPAddress                  IPFIX_TYPE_ipv4Address
+#define IPFIX_DATA_TYPE_mibObjectValueCounter                    IPFIX_TYPE_unsigned64
+#define IPFIX_DATA_TYPE_mibObjectValueGauge                      IPFIX_TYPE_unsigned32
+#define IPFIX_DATA_TYPE_mibObjectValueTimeTicks                  IPFIX_TYPE_unsigned32
+#define IPFIX_DATA_TYPE_mibObjectValueUnsigned                   IPFIX_TYPE_unsigned32
+#define IPFIX_DATA_TYPE_mibObjectValueTable                      IPFIX_TYPE_subTemplateList
+#define IPFIX_DATA_TYPE_mibObjectValueRow                        IPFIX_TYPE_subTemplateList
+#define IPFIX_DATA_TYPE_mibObjectIdentifier                      IPFIX_TYPE_octetArray
+#define IPFIX_DATA_TYPE_mibSubIdentifier                         IPFIX_TYPE_unsigned32
+#define IPFIX_DATA_TYPE_mibIndexIndicator                        IPFIX_TYPE_unsigned64
+#define IPFIX_DATA_TYPE_mibCaptureTimeSemantics                  IPFIX_TYPE_unsigned8
+#define IPFIX_DATA_TYPE_mibContextEngineID                       IPFIX_TYPE_octetArray
+#define IPFIX_DATA_TYPE_mibContextName                           IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_mibObjectName                            IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_mibObjectDescription                     IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_mibObjectSyntax                          IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_mibModuleName                            IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_mobileIMSI                               IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_mobileMSISDN                             IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_httpStatusCode                           IPFIX_TYPE_unsigned16
+#define IPFIX_DATA_TYPE_sourceTransportPortsLimit                IPFIX_TYPE_unsigned16
+#define IPFIX_DATA_TYPE_httpRequestMethod                        IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_httpRequestHost                          IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_httpRequestTarget                        IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_httpMessageVersion                       IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_natInstanceID                            IPFIX_TYPE_unsigned32
+#define IPFIX_DATA_TYPE_internalAddressRealm                     IPFIX_TYPE_octetArray
+#define IPFIX_DATA_TYPE_externalAddressRealm                     IPFIX_TYPE_octetArray
+#define IPFIX_DATA_TYPE_natQuotaExceededEvent                    IPFIX_TYPE_unsigned32
+#define IPFIX_DATA_TYPE_natThresholdEvent                        IPFIX_TYPE_unsigned32
+#define IPFIX_DATA_TYPE_httpUserAgent                            IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_httpContentType                          IPFIX_TYPE_string
+#define IPFIX_DATA_TYPE_httpReasonPhrase                         IPFIX_TYPE_string
+
+#define IPFIX_STRUCTURED_TYPE_SEMANTIC_noneOf                         0x00
+#define IPFIX_STRUCTURED_TYPE_SEMANTIC_exactlyOneOf                   0x01
+#define IPFIX_STRUCTURED_TYPE_SEMANTIC_oneOrMoreOf                    0x02
+#define IPFIX_STRUCTURED_TYPE_SEMANTIC_allOf                          0x03
+#define IPFIX_STRUCTURED_TYPE_SEMANTIC_ordered                        0x04
+#define IPFIX_STRUCTURED_TYPE_SEMANTIC_undefined                      0xFF
 
 
 #endif

--- a/src/common/ipfixlolib/ipfix_names.c
+++ b/src/common/ipfixlolib/ipfix_names.c
@@ -103,6 +103,24 @@ const struct ipfix_identifier* ipfix_name_lookup(const char *name)
 	return NULL;
 }
 
+/*
+ * lookup an ipfix semantic by name
+ */
+const uint8_t* ipfix_semantic_lookup(const char *name)
+{
+	uint32_t i;
+
+    // Search IANA semantic IDs
+    for (i = 0; i<sizeof(ipfixsemantic_iana)/sizeof(struct ipfix_semantic); i++) {
+        if (strcasecmp(name, ipfixsemantic_iana[i].name)==0) {
+            return &(ipfixsemantic_iana[i].id);
+        }
+     }
+
+	/* not found */
+	return NULL;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/ipfixlolib/ipfix_names.h
+++ b/src/common/ipfixlolib/ipfix_names.h
@@ -36,6 +36,11 @@ struct ipfix_identifier {
 	uint16_t type; // IPFIX data type
 };
 
+struct ipfix_semantic {
+	uint16_t id;
+	char *name;
+};
+
 int ipfix_id_rangecheck(int id);
 const struct ipfix_identifier* ipfix_id_lookup(uint16_t id, uint32_t pen);
 const struct ipfix_identifier* ipfix_name_lookup(const char *name);

--- a/src/common/ipfixlolib/ipfix_names.h
+++ b/src/common/ipfixlolib/ipfix_names.h
@@ -37,13 +37,14 @@ struct ipfix_identifier {
 };
 
 struct ipfix_semantic {
-	uint16_t id;
+	uint8_t id;
 	char *name;
 };
 
 int ipfix_id_rangecheck(int id);
 const struct ipfix_identifier* ipfix_id_lookup(uint16_t id, uint32_t pen);
 const struct ipfix_identifier* ipfix_name_lookup(const char *name);
+const uint8_t* ipfix_semantic_lookup(const char *name);
 
 
 #ifdef __cplusplus

--- a/src/core/InfoElementCfg.h
+++ b/src/core/InfoElementCfg.h
@@ -91,6 +91,11 @@ public:
 					THROWEXCEPTION("InfoElementCfg: given fieldIeName \"%s\" could not be mapped to IANA-standardized IE", fieldName.c_str());
 				}
 			}
+
+			// basicList supports only the "ordered" semantic
+			if (semantic != IPFIX_STRUCTURED_TYPE_SEMANTIC_ordered) {
+				THROWEXCEPTION("InfoElementCfg: semantic \"%s\" is not yet supported", semanticName.c_str());
+			}
 		}
 	}
 

--- a/src/core/InfoElementCfg.h
+++ b/src/core/InfoElementCfg.h
@@ -3,6 +3,7 @@
 
 #include "core/Cfg.h"
 #include "common/ipfixlolib/ipfix_names.h"
+#include "common/ipfixlolib/ipfix_iana.h"
 
 
 class InfoElementCfg
@@ -22,6 +23,8 @@ public:
 		modifier         = getOptional("modifier");
 		match            = getOptional("match");
 		autoAddV4PrefixLength = getBool("autoAddV4PrefixLength", true);
+		semanticName = getOptional("semantic");
+		fieldName = getOptional("fieldIeName");
 
 
 		if (ieId>0) {
@@ -66,6 +69,29 @@ public:
 			const ipfix_identifier* ipfixid = ipfix_id_lookup(ieId, enterpriseNumber);
 			if (ipfixid) ieLength = ipfixid->length;
 		}
+
+		// basicList specific
+		if (ieId == IPFIX_TYPEID_basicList && enterpriseNumber == 0) {
+
+			if (semanticName.size() == 0) {
+				semantic = IPFIX_STRUCTURED_TYPE_SEMANTIC_undefined;
+			} else {
+				const uint8_t *semanticPtr = ipfix_semantic_lookup(semanticName.c_str());
+				if (semanticPtr == NULL) {
+					THROWEXCEPTION("InfoElementCfg: semantic \"%s\" could not be mapped to IANA-standardized semantic", semanticName.c_str());
+				}
+				semantic = *semanticPtr;
+			}
+
+			if (fieldName.size() == 0) {
+				THROWEXCEPTION("InfoElementCfg: fieldIeName element is missing for basicList");
+			} else {
+				fieldIe = ipfix_name_lookup(fieldName.c_str());
+				if (fieldIe == NULL) {
+					THROWEXCEPTION("InfoElementCfg: given fieldIeName \"%s\" could not be mapped to IANA-standardized IE", fieldName.c_str());
+				}
+			}
+		}
 	}
 
 	std::string getName() { return "IE"; }
@@ -85,6 +111,10 @@ public:
 	bool isKnownIE() { return knownIE; }
 
 	bool getAutoAddV4PrefixLength() { return autoAddV4PrefixLength; }
+
+	uint8_t getSemantic() { return semantic; }
+
+	const ipfix_identifier* getFieldIe() { return fieldIe; }
 
 	bool operator==(const InfoElementCfg &other) const {
 		if (other.ieLength != ieLength) return false;
@@ -108,6 +138,12 @@ private:
 
 	bool knownIE;
 	bool autoAddV4PrefixLength;
+
+	// basicList specific
+	std::string semanticName;
+	uint8_t semantic;
+	std::string fieldName;
+	const ipfix_identifier* fieldIe;
 };
 
 #endif /*INFOELEMENTCFG_H_*/

--- a/src/modules/ipfix/IpfixPrinter.cpp
+++ b/src/modules/ipfix/IpfixPrinter.cpp
@@ -683,7 +683,7 @@ void IpfixPrinter::printTreeRecord(IpfixDataRecord* record)
 		if (record->templateInfo->fieldInfo[i].type == InformationElement::IeInfo(IPFIX_TYPEID_basicList, 0)) {
 			printFieldDataType(record->templateInfo->fieldInfo[i].type);
 
-			fprintf(fh, "semantic=%hu, %s [", record->templateInfo->fieldInfo[i].basicListData.semantic, record->templateInfo->fieldInfo[i].basicListData.fieldIe->toString().c_str());
+			fprintf(fh, "semantic=%hhu, %s [", record->templateInfo->fieldInfo[i].basicListData.semantic, record->templateInfo->fieldInfo[i].basicListData.fieldIe->toString().c_str());
 
 			vector<void*>** listPtr = (vector<void*>**) (record->data + record->templateInfo->fieldInfo[i].offset);
 			for (vector<void*>::const_iterator iter = (*listPtr)->begin(); iter != (*listPtr)->end(); iter++) {

--- a/src/modules/ipfix/IpfixPrinter.cpp
+++ b/src/modules/ipfix/IpfixPrinter.cpp
@@ -685,13 +685,13 @@ void IpfixPrinter::printTreeRecord(IpfixDataRecord* record)
 
 			fprintf(fh, "semantic=%hhu, %s [", record->templateInfo->fieldInfo[i].basicListData.semantic, record->templateInfo->fieldInfo[i].basicListData.fieldIe->toString().c_str());
 
-			vector<void*>** listPtr = (vector<void*>**) (record->data + record->templateInfo->fieldInfo[i].offset);
-			for (vector<void*>::const_iterator iter = (*listPtr)->begin(); iter != (*listPtr)->end(); iter++) {
+			vector<void*>** listPtrPtr = (vector<void*>**) (record->data + record->templateInfo->fieldInfo[i].offset);
+			for (vector<void*>::const_iterator iter = (*listPtrPtr)->begin(); iter != (*listPtrPtr)->end(); iter++) {
 
 				printFieldDataValue(*record->templateInfo->fieldInfo[i].basicListData.fieldIe, reinterpret_cast<IpfixRecord::Data*>(*iter));
 
 				// No comma for last element in the list
-				if (iter+1 != (*listPtr)->end()) {
+				if (iter+1 != (*listPtrPtr)->end()) {
 					fprintf(fh, ", ");
 				}
 			}

--- a/src/modules/ipfix/IpfixPrinter.hpp
+++ b/src/modules/ipfix/IpfixPrinter.hpp
@@ -31,6 +31,8 @@ class PrintHelpers
 		PrintHelpers() : fh(stdout) {}
 
 		void printFieldData(InformationElement::IeInfo type, IpfixRecord::Data* pattern);
+		void printFieldDataType(InformationElement::IeInfo type);
+		void printFieldDataValue(InformationElement::IeInfo type, IpfixRecord::Data* pattern);
 		void printIPv4(uint32_t data);
 		void printIPv4(InformationElement::IeInfo type, IpfixRecord::Data* data);
 		void printPort(InformationElement::IeInfo type, IpfixRecord::Data* data);

--- a/src/modules/ipfix/IpfixRecord.hpp
+++ b/src/modules/ipfix/IpfixRecord.hpp
@@ -352,14 +352,14 @@ class IpfixDataRecord : public IpfixRecord, public ManagedInstance<IpfixDataReco
 				// Free basicList memory
 				if (templateInfo->fieldInfo[i].type == InformationElement::IeInfo(IPFIX_TYPEID_basicList, 0)) {
 					IpfixRecord::Data* dst = (data + templateInfo->fieldInfo[i].offset);
-					vector<void*>** listPtr = (vector<void*>**) dst;
+					vector<void*>** listPtrPtr = (vector<void*>**) dst;
 
-					if (*listPtr != NULL) {
-						for (vector<void*>::const_iterator iter = (*listPtr)->begin(); iter != (*listPtr)->end(); iter++) {
+					if (*listPtrPtr != NULL) {
+						for (vector<void*>::const_iterator iter = (*listPtrPtr)->begin(); iter != (*listPtrPtr)->end(); iter++) {
 							free(reinterpret_cast<IpfixRecord::Data*>(*iter));
 						}
 
-						delete *listPtr;
+						delete *listPtrPtr;
 					}
 				}
 			}

--- a/src/modules/ipfix/IpfixRecord.hpp
+++ b/src/modules/ipfix/IpfixRecord.hpp
@@ -208,13 +208,26 @@ class IpfixRecord
 		boost::shared_ptr<IpfixRecord::SourceID> sourceID;
 
 		IpfixRecord() {}
-		virtual ~IpfixRecord() {}
+
+		virtual ~IpfixRecord() {
+			if (variableLenData != NULL) {
+				free(variableLenData);
+				variableLenData = NULL;
+			}
+		}
 
 		/**
 		 * all subclasses *MUST* inherit ManagedInstance, which implements these methods
 		 */
 		virtual void removeReference() = 0;
 		virtual void addReference(int count = 1) = 0;
+
+		// We can not use local variables on the stack for variable length IEs as the record memory is copied only later in the sending process
+		// We therefore need malloc'ed memory for encoding variable length IEs such as basicList
+		uint8_t threeByteIndicator = 255;
+		IpfixRecord::Data* variableLenData = NULL;
+		unsigned int variableLenDataTotalBytes = 100;
+		unsigned int variableLenDataCurrBytes = 0;
 };
 
 
@@ -224,6 +237,11 @@ class IpfixRecord
 class TemplateInfo {
 	public:
 		typedef uint16_t TemplateId;
+
+		struct BasicListData {
+			uint8_t semantic;
+			InformationElement::IeInfo* fieldIe;
+		};
 
 		enum SetId {
 			UnknownSetId = -1,
@@ -241,6 +259,7 @@ class TemplateInfo {
 			int32_t offset; 	/**< offset in bytes from a data start pointer. For internal purposes 0xFFFFFFFF is defined as yet unknown */
 			int32_t privDataOffset; /**< offset in bytes from data start pointer for internal private data which is not exported via IPFIX */
 			bool isVariableLength; 	/**< true if this field's length might change from record to record, false otherwise */
+			struct BasicListData basicListData; /**< additional information for basic list IE */
 		};
 
 		TemplateInfo();
@@ -324,7 +343,36 @@ class IpfixDataRecord : public IpfixRecord, public ManagedInstance<IpfixDataReco
 		IpfixRecord::Data* data; /**< pointer to start of field data in @c message. Undefined after @c message goes out of scope. */
 
 		// redirector to reference remover of ManagedInstance
-		virtual void removeReference() { ManagedInstance<IpfixDataRecord>::removeReference(); }
+		virtual void removeReference() {
+
+			// Remove allocated vector data for basicList elements
+			// NOTE: This can not be done in BaseHashtable::destroyBucket() as this leads to corrupted memory when sending in IpfixSender
+			for (int i = 0; i < templateInfo->fieldCount; i++) {
+
+				// Free basicList memory
+				if (templateInfo->fieldInfo[i].type == InformationElement::IeInfo(IPFIX_TYPEID_basicList, 0)) {
+					IpfixRecord::Data* dst = (data + templateInfo->fieldInfo[i].offset);
+					vector<void*>** listPtr = (vector<void*>**) dst;
+
+					if (*listPtr != NULL) {
+						for (vector<void*>::const_iterator iter = (*listPtr)->begin(); iter != (*listPtr)->end(); iter++) {
+							free(reinterpret_cast<IpfixRecord::Data*>(*iter));
+						}
+
+						delete *listPtr;
+					}
+				}
+			}
+
+			// Clean previously used variable length data
+			if (variableLenData != NULL) {
+				variableLenDataCurrBytes = 0;
+				free(variableLenData);
+				variableLenData = NULL;
+			}
+
+			ManagedInstance<IpfixDataRecord>::removeReference();
+		}
 		virtual void addReference(int count = 1) { ManagedInstance<IpfixDataRecord>::addReference(count); }
 };
 

--- a/src/modules/ipfix/IpfixSender.cpp
+++ b/src/modules/ipfix/IpfixSender.cpp
@@ -597,7 +597,7 @@ void IpfixSender::addDataRecordValue(TemplateInfo::FieldInfo* fi, IpfixRecord::D
 void IpfixSender::sendDataFromVarLenDataBuff(IpfixDataRecord* record, void* data, size_t len)
 {
 	if (record->variableLenDataCurrBytes + len > record->variableLenDataTotalBytes) {
-		THROWEXCEPTION("Not enough bytes allocated: %zu allocated, %zu needed", record->variableLenDataTotalBytes, record->variableLenDataCurrBytes + len);
+		THROWEXCEPTION("Not enough bytes allocated: %u allocated, %u needed", record->variableLenDataTotalBytes, record->variableLenDataCurrBytes + (unsigned int) len);
 	}
 
 	memcpy(&(record->variableLenData[record->variableLenDataCurrBytes]), data, len);

--- a/src/modules/ipfix/IpfixSender.cpp
+++ b/src/modules/ipfix/IpfixSender.cpp
@@ -567,37 +567,13 @@ void IpfixSender::onDataRecord(IpfixDataRecord* record)
 
 	setTemplateId(my_template_id, record->dataLength);
 
+	// Set variable length data based on template estimation to avoid realloc
+	initVarLenData(record, data);
+
 	int i;
 	for (i = 0; i < dataTemplateInfo->fieldCount; i++) {
-		TemplateInfo::FieldInfo* fi = &dataTemplateInfo->fieldInfo[i];
-
-		/* Split IPv4 fields with length 5, i.e. fields with network mask attached */
-		if ((fi->type.id == IPFIX_TYPEID_sourceIPv4Address) && (fi->type.length == 5)) {
-			uint8_t* mask = &conversionRingbuffer[ringbufferPos++];
-			*mask = 32 - *(uint8_t*)(data + fi->offset + 4);
-			ipfix_put_data_field(ipfixExporter, data + fi->offset, 4);
-			ipfix_put_data_field(ipfixExporter, mask, 1);
-		}
-		else if ((fi->type.id == IPFIX_TYPEID_destinationIPv4Address) && (fi->type.length == 5)) {
-			uint8_t* mask = &conversionRingbuffer[ringbufferPos++];
-			*mask = 32 - *(uint8_t*)(data + fi->offset + 4);
-			ipfix_put_data_field(ipfixExporter, data + fi->offset, 4);
-			ipfix_put_data_field(ipfixExporter, mask, 1);
-		}
-		else if ((export_protocol == NFV9_PROTOCOL) &&
-				(fi->type.id == IPFIX_TYPEID_tcpControlBits) &&
-				(fi->type.length != 1)) {
-			// data is in network order, we want just the second byte as per RFC
-			ipfix_put_data_field(ipfixExporter, data + fi->offset + 1, 1);
-		}
-		else {
-			if (fi->type.id == IPFIX_TYPEID_packetDeltaCount && fi->type.length<=8) {
-				uint64_t p = 0;
-				memcpy(&p, data+fi->offset, fi->type.length);
-				statPacketsInFlows += ntohll(p);
-			}
-			ipfix_put_data_field(ipfixExporter, data + fi->offset, fi->type.length);
-		}
+		TemplateInfo::FieldInfo* fi = &(dataTemplateInfo->fieldInfo[i]);
+		addDataRecordValue(fi, data, record);
 	}
 	remainingSpace -= record->dataLength;
 	statSentDataRecords++;
@@ -611,6 +587,122 @@ void IpfixSender::onDataRecord(IpfixDataRecord* record)
 
 	// release the message lock
 	ipfixMessageLock.unlock();
+}
+
+void IpfixSender::addDataRecordValue(TemplateInfo::FieldInfo* fi, IpfixRecord::Data* data)
+{
+	addDataRecordValue(fi, data, NULL);
+}
+
+void IpfixSender::sendDataFromVarLenDataBuff(IpfixDataRecord* record, void* data, size_t len)
+{
+	if (record->variableLenDataCurrBytes + len > record->variableLenDataTotalBytes) {
+		THROWEXCEPTION("Not enough bytes allocated: %zu allocated, %zu needed", record->variableLenDataTotalBytes, record->variableLenDataCurrBytes + len);
+	}
+
+	memcpy(&(record->variableLenData[record->variableLenDataCurrBytes]), data, len);
+	ipfix_put_data_field(ipfixExporter, &record->variableLenData[record->variableLenDataCurrBytes], len);
+	record->variableLenDataCurrBytes += len;
+}
+
+void IpfixSender::initVarLenData(IpfixDataRecord* record, IpfixRecord::Data* data)
+{
+	size_t varLenDataTotalSize = 0;
+
+	for (int i = 0; i < record->templateInfo->fieldCount; i++) {
+		TemplateInfo::FieldInfo* fi = &(record->templateInfo->fieldInfo[i]);
+		if (fi->type.id == IPFIX_TYPEID_basicList) {
+			vector<void*>** listPtr = (vector<void*>**) (data + fi->offset);
+			// Variable length IE length field (2B) + Semantic (1B) + Field ID (2B) + Element Length (2B) + (optional: Enterprise Number (3B)) + basicList Content (variable)
+			// NOTE: Even though some of these fields are not copied to the variableLenData, we include them in the varLenDataTotalSize estimation
+			varLenDataTotalSize += 2 + 1 + 2 + 2;
+			varLenDataTotalSize += (fi->basicListData.fieldIe->enterprise == 0) ? 0 : 3;
+			varLenDataTotalSize += ((*listPtr)->size()) * fi->basicListData.fieldIe->length;
+		}
+	}
+
+	// Allocate memory if variable length is present
+	if (varLenDataTotalSize > 0) {
+		if (record->variableLenData != NULL) {
+			free(record->variableLenData);
+			record->variableLenData = NULL;
+			record->variableLenDataCurrBytes = 0;
+		}
+		record->variableLenDataTotalBytes = varLenDataTotalSize;
+		record->variableLenData = (IpfixRecord::Data*) malloc(record->variableLenDataTotalBytes);
+	}
+}
+
+void IpfixSender::addDataRecordValue(TemplateInfo::FieldInfo* fi, IpfixRecord::Data* data, IpfixDataRecord* record)
+{
+
+	/* Split IPv4 fields with length 5, i.e. fields with network mask attached */
+	if ((fi->type.id == IPFIX_TYPEID_sourceIPv4Address) && (fi->type.length == 5)) {
+		uint8_t* mask = &conversionRingbuffer[ringbufferPos++];
+		*mask = 32 - *(uint8_t*)(data + fi->offset + 4);
+		ipfix_put_data_field(ipfixExporter, data + fi->offset, 4);
+		ipfix_put_data_field(ipfixExporter, mask, 1);
+	}
+	else if ((fi->type.id == IPFIX_TYPEID_destinationIPv4Address) && (fi->type.length == 5)) {
+		uint8_t* mask = &conversionRingbuffer[ringbufferPos++];
+		*mask = 32 - *(uint8_t*)(data + fi->offset + 4); // TODO FIXME Valgrind complains due to uninitialized memory!!!
+		ipfix_put_data_field(ipfixExporter, data + fi->offset, 4);
+		ipfix_put_data_field(ipfixExporter, mask, 1);
+	}
+	else if ((export_protocol == NFV9_PROTOCOL) &&
+			(fi->type.id == IPFIX_TYPEID_tcpControlBits) &&
+			(fi->type.length != 1)) {
+		// data is in network order, we want just the second byte as per RFC
+		ipfix_put_data_field(ipfixExporter, data + fi->offset + 1, 1);
+	}
+	else if (fi->type.id == IPFIX_TYPEID_basicList) {
+		vector<void*>** listPtr = (vector<void*>**) (data + fi->offset);
+
+		// Always use three-byte length encoding as RECOMMENDED in RFC 6313
+		ipfix_put_data_field(ipfixExporter, &record->threeByteIndicator, 1);
+
+		// Need to allocate memory to store length etc. as they are not immediately sent over the wire
+		// Is deallocated in IpfixRecord destructor
+		if (record->variableLenData == NULL) {
+			msg(MSG_ERROR, "Variable length data present but variableLenData not allocated.");
+		}
+
+		// Semantic (1B) + Field ID (2B) + Element Length (2B) + (optional: Enterprise Number (3B)) + basicList Content (variable)
+		uint16_t varLen = 1 + 2 + 2;
+		varLen += (fi->basicListData.fieldIe->enterprise == 0) ? 0 : 3;
+		varLen += ((*listPtr)->size()) * fi->basicListData.fieldIe->length;
+		varLen = htons(varLen);
+
+		sendDataFromVarLenDataBuff(record, &varLen, sizeof(varLen));
+
+
+		// Var length field
+		// Semantic
+		ipfix_put_data_field(ipfixExporter, (void *) &fi->basicListData.semantic, 1);
+
+		// Field ID
+		// TODO: Distinguish between enterprise=0
+		uint16_t fieldId = htons(fi->basicListData.fieldIe->id);
+		sendDataFromVarLenDataBuff(record, &fieldId, sizeof(fieldId));
+
+		// Field length
+		uint16_t fieldLen = htons(fi->basicListData.fieldIe->length);
+		sendDataFromVarLenDataBuff(record, &fieldLen, sizeof(fieldLen));
+
+		// Add basicList content
+		for (vector<void*>::const_iterator iter = (*listPtr)->begin(); iter != (*listPtr)->end(); iter++) {
+			IpfixRecord::Data* elem = reinterpret_cast<IpfixRecord::Data*>(*iter);
+			sendDataFromVarLenDataBuff(record, elem, ntohs(fieldLen));
+		}
+	}
+	else {
+		if (fi->type.id == IPFIX_TYPEID_packetDeltaCount && fi->type.length<=8) {
+			uint64_t p = 0;
+			memcpy(&p, data+fi->offset, fi->type.length);
+			statPacketsInFlows += ntohll(p);
+		}
+		ipfix_put_data_field(ipfixExporter, data + fi->offset, fi->type.length);
+	}
 }
 
 /**

--- a/src/modules/ipfix/IpfixSender.hpp
+++ b/src/modules/ipfix/IpfixSender.hpp
@@ -96,6 +96,10 @@ private:
 	void registerTimeout();
 	void onSendRecordsTimeout(void);
 	void registerBeatTimeout();
+	void addDataRecordValue(TemplateInfo::FieldInfo*, IpfixRecord::Data*);
+	void addDataRecordValue(TemplateInfo::FieldInfo*, IpfixRecord::Data*, IpfixDataRecord*);
+	void sendDataFromVarLenDataBuff(IpfixDataRecord*, void*, size_t);
+	void initVarLenData(IpfixDataRecord*, IpfixRecord::Data*);
 
 	TemplateInfo::TemplateId getUnusedTemplateId();
 

--- a/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
+++ b/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
@@ -120,6 +120,9 @@ Rule::Field* AggregatorBaseCfg::readNonFlowKeyRule(XMLElement* e)
 	ruleField->type.enterprise = ie.getEnterpriseNumber();
 	ruleField->type.length = ie.getIeLength();
 
+	ruleField->semantic = ie.getSemantic();
+	ruleField->fieldIe = ie.getFieldIe();
+
 	if (ie.getAutoAddV4PrefixLength() &&
 			(ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_sourceIPv4Address, 0) ||
 			ruleField->type == InformationElement::IeInfo(IPFIX_TYPEID_destinationIPv4Address, 0))) {

--- a/src/modules/ipfix/aggregator/PacketHashtable.cpp
+++ b/src/modules/ipfix/aggregator/PacketHashtable.cpp
@@ -292,6 +292,7 @@ void (*PacketHashtable::getCopyDataFunction(const ExpFieldData* efd))(CopyFuncPa
 				case IPFIX_TYPEID_sourceTransportPort:
 				case IPFIX_TYPEID_destinationTransportPort:
 				case IPFIX_TYPEID_icmpTypeCodeIPv4:
+				case IPFIX_TYPEID_totalLengthIPv4:
 					if (efd->dstLength != 2) {
 						THROWEXCEPTION("unsupported length %d for type %s", efd->dstLength, efd->typeId.toString().c_str());
 					}
@@ -464,6 +465,7 @@ uint8_t PacketHashtable::getRawPacketFieldLength(const IeInfo& type)
 			case IPFIX_TYPEID_destinationTransportPort:
 			case IPFIX_TYPEID_octetDeltaCount:
 			case IPFIX_TYPEID_octetTotalCount:
+			case IPFIX_TYPEID_totalLengthIPv4:
 				return 2;
 
 			case IPFIX_TYPEID_flowStartSeconds:
@@ -570,6 +572,7 @@ int32_t PacketHashtable::getRawPacketFieldOffset(const IeInfo& type, const Packe
 
 			case IPFIX_TYPEID_octetDeltaCount:
 			case IPFIX_TYPEID_octetTotalCount:
+			case IPFIX_TYPEID_totalLengthIPv4:
 				return 2;
 				break;
 
@@ -669,6 +672,7 @@ bool PacketHashtable::isRawPacketPtrVariable(const IeInfo& type)
 				case IPFIX_TYPEID_ipClassOfService:
 				case IPFIX_TYPEID_bgpSourceAsNumber:
 				case IPFIX_TYPEID_bgpDestinationAsNumber:
+				case IPFIX_TYPEID_totalLengthIPv4:
 					return false;
 
 				case IPFIX_TYPEID_icmpTypeCodeIPv4:
@@ -801,6 +805,7 @@ bool PacketHashtable::typeAvailable(const IeInfo& type)
 				case IPFIX_TYPEID_tcpControlBits:
 				case IPFIX_TYPEID_bgpSourceAsNumber:
 				case IPFIX_TYPEID_bgpDestinationAsNumber:
+				case IPFIX_TYPEID_totalLengthIPv4:
 					return true;
 			}
 			break;

--- a/src/modules/ipfix/aggregator/PacketHashtable.cpp
+++ b/src/modules/ipfix/aggregator/PacketHashtable.cpp
@@ -126,6 +126,26 @@ void PacketHashtable::copyDataNanoseconds(CopyFuncParameters* cfp)
 	}
 #endif
 }
+void PacketHashtable::copyDataBasicList(CopyFuncParameters* cfp)
+{
+	ExpFieldData* efd = cfp->efd;
+	IpfixRecord::Data* dst = cfp->dst+efd->dstIndex;
+	vector<void*>** listPtr = (vector<void*>**) dst;
+	size_t len = efd->typeSpecData.basicList->fieldIe->length;
+
+	// Initialize vector
+	if (*listPtr == NULL) {
+		*listPtr = new vector<void*>;
+	} else {
+		THROWEXCEPTION("basicList vector was initially not NULL.");
+	}
+
+	// Is called to insert first element
+	void* toInsert = malloc(len);
+	memcpy(toInsert, cfp->src, len);
+
+	(*listPtr)->push_back((void*) toInsert);
+}
 void PacketHashtable::copyDataTransportOctets(CopyFuncParameters* cfp)
 {
 	const Packet* p = cfp->packet;
@@ -349,6 +369,9 @@ void (*PacketHashtable::getCopyDataFunction(const ExpFieldData* efd))(CopyFuncPa
 					}
 					break;
 
+				case IPFIX_TYPEID_basicList:
+					break;
+
 				default:
 					THROWEXCEPTION("type unhandled by Packet Aggregator: %s", efd->typeId.toString().c_str());
 					break;
@@ -416,6 +439,8 @@ void (*PacketHashtable::getCopyDataFunction(const ExpFieldData* efd))(CopyFuncPa
 	} else if (efd->typeId == IeInfo(IPFIX_TYPEID_flowStartNanoseconds, 0) ||
 			efd->typeId == IeInfo(IPFIX_TYPEID_flowEndNanoseconds, 0)) {
 		return copyDataNanoseconds;
+	} else if (efd->typeId == IeInfo(IPFIX_TYPEID_basicList, 0)) {
+		return copyDataBasicList;
 	} else if (efd->typeId.enterprise & IPFIX_PEN_reverse) {
 		// ATTENTION: we treat all reverse elements the same: we set them to zero
 		return copyDataSetZero;
@@ -440,7 +465,7 @@ void (*PacketHashtable::getCopyDataFunction(const ExpFieldData* efd))(CopyFuncPa
 			return copyDataGreaterLengthNoMod;
 		}
 	} else {
-		THROWEXCEPTION("target buffer too small. Expected buffer %s of length %d", efd->typeId.toString().c_str(), efd->srcLength);
+		THROWEXCEPTION("target buffer too small. Expected buffer %s of length %d, but got %d", efd->typeId.toString().c_str(), efd->srcLength, efd->dstLength);
 	}
 
 	THROWEXCEPTION("this line should never be reached");
@@ -538,7 +563,12 @@ uint8_t PacketHashtable::getRawPacketFieldLength(const IeInfo& type)
  * @param p pointer to raw packet
  * @returns offset (in bytes) at which the data for the given field is located in the raw packet
  */
-int32_t PacketHashtable::getRawPacketFieldOffset(const IeInfo& type, const Packet* p)
+ int32_t PacketHashtable::getRawPacketFieldOffset(const IeInfo& type, const Packet* p)
+ {
+	 return getRawPacketFieldOffset(type, p, NULL);
+ }
+
+int32_t PacketHashtable::getRawPacketFieldOffset(const IeInfo& type, const Packet* p, const ExpFieldData::TypeSpecificData* typeSpecData)
 {
 	if (type.enterprise==0 || type.enterprise==IPFIX_PEN_reverse) {
 		switch (type.id) {
@@ -627,6 +657,12 @@ int32_t PacketHashtable::getRawPacketFieldOffset(const IeInfo& type, const Packe
 					DPRINTFL(MSG_VDEBUG, "given id is %s, protocol is %d, but expected was %d", type.toString().c_str(), p->ipProtocolType, Packet::TCP);
 				}
 				break;
+
+			case IPFIX_TYPEID_basicList:
+				// Find offset for field inside basicList
+				return getRawPacketFieldOffset(*typeSpecData->basicList->fieldIe, p);
+				break;
+
 			default:
 				THROWEXCEPTION("PacketHashtable: raw id offset into packet header for typeid %s is unkown, failed to determine raw packet offset", type.toString().c_str());
 				break;
@@ -681,6 +717,7 @@ bool PacketHashtable::isRawPacketPtrVariable(const IeInfo& type)
 				case IPFIX_TYPEID_tcpControlBits:
 				case IPFIX_TYPEID_sourceMacAddress:
 				case IPFIX_TYPEID_destinationMacAddress:
+				case IPFIX_TYPEID_basicList:
 					return true;
 			}
 			break;
@@ -717,16 +754,23 @@ void PacketHashtable::fillExpFieldData(ExpFieldData* efd, TemplateInfo::FieldInf
 	DPRINTFL(MSG_VDEBUG, "called for type id %s", hfi->type.toString().c_str());
 	efd->typeId = hfi->type;
 	efd->dstIndex = hfi->offset;
-	efd->dstLength = hfi->type.length;
-	efd->srcLength = getRawPacketFieldLength(hfi->type);
 	efd->modifier = fieldModifier;
-	efd->varSrcIdx = isRawPacketPtrVariable(hfi->type);
+
+	IeInfo ie = hfi->type;
+	if (hfi->type == IeInfo(IPFIX_TYPEID_basicList, 0)) {
+		efd->typeSpecData.basicList = &hfi->basicListData;
+		ie = *efd->typeSpecData.basicList->fieldIe;
+	}
+
+	efd->dstLength = ie.length;
+	efd->srcLength = getRawPacketFieldLength(ie);
+	efd->varSrcIdx = isRawPacketPtrVariable(ie);
 	efd->privDataOffset = hfi->privDataOffset;
 
 	// initialize static source index, if current field does not have a variable pointer
 	if (!efd->varSrcIdx) {
 		Packet p; // not good: create temporary packet just for initializing our optimization structure
-		efd->srcIndex = getRawPacketFieldOffset(hfi->type, &p);
+		efd->srcIndex = getRawPacketFieldOffset(ie, &p, &efd->typeSpecData);
 	}
 
 	// special case for masked IPs: those contain variable pointers, if they are masked
@@ -806,6 +850,7 @@ bool PacketHashtable::typeAvailable(const IeInfo& type)
 				case IPFIX_TYPEID_bgpSourceAsNumber:
 				case IPFIX_TYPEID_bgpDestinationAsNumber:
 				case IPFIX_TYPEID_totalLengthIPv4:
+				case IPFIX_TYPEID_basicList:
 					return true;
 			}
 			break;
@@ -1192,6 +1237,21 @@ void PacketHashtable::aggregateField(const ExpFieldData* efd, HashtableBucket* h
 						}
 						break;
 
+					case IPFIX_TYPEID_basicList:
+						// Is called to insert all but first elements
+						size_t len;
+						void* toInsert;
+						vector<void*>** listPtr;
+
+						len = efd->typeSpecData.basicList->fieldIe->length;
+						toInsert = malloc(len);
+						listPtr = (vector<void*>**) baseData;
+
+						memcpy(toInsert, deltaData, len);
+						(*listPtr)->push_back((void*) toInsert);
+
+						break;
+
 						// no other types needed, as this is only for raw field input
 					default:
 						DPRINTF("non-aggregatable type: %s", efd->typeId.toString().c_str());
@@ -1483,7 +1543,7 @@ void PacketHashtable::updatePointers(const Packet* p)
 		}
 		if (dodefault) {
 			// standard procedure for transport header fields
-			efd->srcIndex = getRawPacketFieldOffset(efd->typeId, p);
+			efd->srcIndex = getRawPacketFieldOffset(efd->typeId, p, &efd->typeSpecData);
 		}
 	}
 }

--- a/src/modules/ipfix/aggregator/PacketHashtable.cpp
+++ b/src/modules/ipfix/aggregator/PacketHashtable.cpp
@@ -130,12 +130,12 @@ void PacketHashtable::copyDataBasicList(CopyFuncParameters* cfp)
 {
 	ExpFieldData* efd = cfp->efd;
 	IpfixRecord::Data* dst = cfp->dst+efd->dstIndex;
-	vector<void*>** listPtr = (vector<void*>**) dst;
+	vector<void*>** listPtrPtr = (vector<void*>**) dst;
 	size_t len = efd->typeSpecData.basicList->fieldIe->length;
 
 	// Initialize vector
-	if (*listPtr == NULL) {
-		*listPtr = new vector<void*>;
+	if (*listPtrPtr == NULL) {
+		*listPtrPtr = new vector<void*>;
 	} else {
 		THROWEXCEPTION("basicList vector was initially not NULL.");
 	}
@@ -144,7 +144,7 @@ void PacketHashtable::copyDataBasicList(CopyFuncParameters* cfp)
 	void* toInsert = malloc(len);
 	memcpy(toInsert, cfp->src, len);
 
-	(*listPtr)->push_back((void*) toInsert);
+	(*listPtrPtr)->push_back((void*) toInsert);
 }
 void PacketHashtable::copyDataTransportOctets(CopyFuncParameters* cfp)
 {
@@ -1241,14 +1241,14 @@ void PacketHashtable::aggregateField(const ExpFieldData* efd, HashtableBucket* h
 						// Is called to insert all but first elements
 						size_t len;
 						void* toInsert;
-						vector<void*>** listPtr;
+						vector<void*>** listPtrPtr;
 
 						len = efd->typeSpecData.basicList->fieldIe->length;
 						toInsert = malloc(len);
-						listPtr = (vector<void*>**) baseData;
+						listPtrPtr = (vector<void*>**) baseData;
 
 						memcpy(toInsert, deltaData, len);
-						(*listPtr)->push_back((void*) toInsert);
+						(*listPtrPtr)->push_back((void*) toInsert);
 
 						break;
 

--- a/src/modules/ipfix/aggregator/PacketHashtable.h
+++ b/src/modules/ipfix/aggregator/PacketHashtable.h
@@ -34,15 +34,7 @@
 
 class PacketHashtable : public BaseHashtable
 {
-public:
-	PacketHashtable(Source<IpfixRecord*>* recordsource, Rule* rule,
-			uint16_t inactiveTimeout, uint16_t activeTimeout, uint8_t hashbits);
-	virtual ~PacketHashtable();
 
-	void aggregatePacket(Packet* p);
-
-	static uint8_t getRawPacketFieldLength(const InformationElement::IeInfo& type);
-	static int32_t getRawPacketFieldOffset(const InformationElement::IeInfo& type, const Packet* p);
 
 private:
 	/**
@@ -104,6 +96,7 @@ private:
 				uint32_t fpaLenOffset; /**< offset from start of record data to IPFIX_ETYPE_FRONTPAYLOADLEN, 0xFFFFFFFF if not used */
 				bool dpa; /**< set to true, if DPA was activated */
 			} frontPayload;
+			TemplateInfo::BasicListData *basicList;
 		} typeSpecData;
 
 	};
@@ -147,6 +140,7 @@ private:
 	static void copyDataSetZero(CopyFuncParameters* cfp);
 	static void copyDataMaxPacketGap(CopyFuncParameters* cfp);
 	static void copyDataNanoseconds(CopyFuncParameters* cfp);
+	static void copyDataBasicList(CopyFuncParameters* cfp);
 	static void copyDataDummy(CopyFuncParameters* cfp);
 	static void copyDataTransportOctets(CopyFuncParameters* cfp);
 	static void aggregateFrontPayload(IpfixRecord::Data* bucket, HashtableBucket* hbucket, const Packet* src,
@@ -169,6 +163,18 @@ private:
 	void updateBucketData(HashtableBucket* bucket);
 	uint32_t getDstOffset(const InformationElement::IeInfo& ietype);
 	bool mustExpireBucket(const HashtableBucket* bucket, const Packet* p);
+	void destroyExpFieldData(ExpFieldData* efd, int numFields); // TODO: Do we need this?
+
+public:
+	PacketHashtable(Source<IpfixRecord*>* recordsource, Rule* rule,
+			uint16_t inactiveTimeout, uint16_t activeTimeout, uint8_t hashbits);
+	virtual ~PacketHashtable();
+
+	void aggregatePacket(Packet* p);
+
+	static uint8_t getRawPacketFieldLength(const InformationElement::IeInfo& type);
+	static int32_t getRawPacketFieldOffset(const InformationElement::IeInfo& type, const Packet* p);
+	static int32_t getRawPacketFieldOffset(const InformationElement::IeInfo& type, const Packet* p, const ExpFieldData::TypeSpecificData* typeSpecData);
 
 };
 

--- a/src/modules/ipfix/aggregator/Rule.hpp
+++ b/src/modules/ipfix/aggregator/Rule.hpp
@@ -49,6 +49,9 @@ class Rule : private PrintHelpers {
 					type.enterprise = 0;
 					pattern = NULL;
 					modifier = Rule::Field::DISCARD;
+
+					semantic = IPFIX_STRUCTURED_TYPE_SEMANTIC_undefined;
+					fieldIe = NULL;
 				}
 
 				~Field() {
@@ -66,6 +69,10 @@ class Rule : private PrintHelpers {
 				InformationElement::IeInfo type; /**< field type this Rule::Field refers to */
 				IpfixRecord::Data* pattern; /**< pattern to match fields against to determine applicability of a rule. A pattern of NULL means no pattern needs to be matched for this field */
 				Rule::Field::Modifier modifier; /**< modifier to apply to the corresponding field if this rule is matched */
+
+				// basicList specific
+				uint8_t semantic;
+				const ipfix_identifier* fieldIe;
 		};
 
 

--- a/tools/iana_ipfix_parser/parse_iana_ipfix_elements.py
+++ b/tools/iana_ipfix_parser/parse_iana_ipfix_elements.py
@@ -63,15 +63,19 @@ def parse_iana_csv_data_types(fh, out):
     out.write(length_macros)
     out.write("\n")
 
-def parse_iana_csv_structured_data_types(fh, out):
+def parse_iana_csv_structured_data_types(fh, out, struct_out):
 
     # Value,Name,Description,Reference
     reader = csv.reader(fh)
+    struct = "\n\nstruct ipfix_semantic ipfixsemantic_iana[] = {\n/* IANA registry */\n"
     for row in reader:
         if row[2] != "unassigned" and row[0] != "Value":
             out.write("#define IPFIX_STRUCTURED_TYPE_SEMANTIC_{0:30} {1}\n".format(row[1], row[0]))
+            struct += '  {{ IPFIX_STRUCTURED_TYPE_SEMANTIC_{0:30}, {1:10} }},\n'.format(row[1], '"' + row[1] + '"')
+    struct += "};\n\n"
 
     out.write("\n")
+    struct_out.write(struct)
 
 def append_output(row, ids, types, lengths, struct):
     elementId = row[0]
@@ -112,7 +116,7 @@ def generate_ipfix_output(ie_fh, types_fh, structured_types_fh, out, struct_out)
 
     parse_iana_csv_data_types(types_fh, out)
     parse_iana_csv_ie(ie_fh, out, struct_out)
-    parse_iana_csv_structured_data_types(structured_types_fh, out)
+    parse_iana_csv_structured_data_types(structured_types_fh, out, struct_out)
 
     # Footer
     struct_out.write('#ifdef __cplusplus\n}\n#endif\n')

--- a/tools/iana_ipfix_parser/parse_iana_ipfix_elements.py
+++ b/tools/iana_ipfix_parser/parse_iana_ipfix_elements.py
@@ -13,6 +13,7 @@ import urllib.request
 
 IANA_IE_URL = "http://www.iana.org/assignments/ipfix/ipfix-information-elements.csv"
 IANA_DATA_TYPES_URL = "http://www.iana.org/assignments/ipfix/ipfix-information-element-data-types.csv"
+IANA_STRUCTURED_DATA_TYPES_URL = "https://www.iana.org/assignments/ipfix/ipfix-structured-data-types-semantics.csv"
 
 class IanaDialect(csv.Dialect):
     # ElementID,Name,Data Type,Data Type Semantics,Status,Description,Units,Range,References,Requester,Revision,Date^M
@@ -62,6 +63,15 @@ def parse_iana_csv_data_types(fh, out):
     out.write(length_macros)
     out.write("\n")
 
+def parse_iana_csv_structured_data_types(fh, out):
+
+    # Value,Name,Description,Reference
+    reader = csv.reader(fh)
+    for row in reader:
+        if row[2] != "unassigned" and row[0] != "Value":
+            out.write("#define IPFIX_STRUCTURED_TYPE_SEMANTIC_{0:30} {1}\n".format(row[1], row[0]))
+
+    out.write("\n")
 
 def append_output(row, ids, types, lengths, struct):
     elementId = row[0]
@@ -95,13 +105,14 @@ def type_to_length(data_type):
     raise Exception("Could not convert data type " + data_type)
 
 
-def generate_ipfix_output(ie_fh, types_fh, out, struct_out):
+def generate_ipfix_output(ie_fh, types_fh, structured_types_fh, out, struct_out):
     # Header
     out.write('#ifndef IPFIX_IANA_H\n#define IPFIX_IANA_H\n\n#include "ipfix_names.h"\n\n')
     struct_out.write('#include "ipfix_iana.h"\n\n#ifdef __cplusplus\nextern "C" {\n#endif\n\n')
 
     parse_iana_csv_data_types(types_fh, out)
     parse_iana_csv_ie(ie_fh, out, struct_out)
+    parse_iana_csv_structured_data_types(structured_types_fh, out)
 
     # Footer
     struct_out.write('#ifdef __cplusplus\n}\n#endif\n')
@@ -113,7 +124,7 @@ def generate_ipfix_output(ie_fh, types_fh, out, struct_out):
 
 
 def download_csvs():
-    for url in (IANA_IE_URL, IANA_DATA_TYPES_URL):
+    for url in (IANA_IE_URL, IANA_DATA_TYPES_URL, IANA_STRUCTURED_DATA_TYPES_URL):
         response = urllib.request.urlopen(url)
         data = response.read().decode('utf-8')
         fh = tempfile.TemporaryFile(mode='w+t')
@@ -126,6 +137,7 @@ def main():
     parser = argparse.ArgumentParser(description='Create C output for IPFIX Information Elements to be used in Vermont.')
     parser.add_argument('-i', '--ie-file', metavar='IE_CSV', type=argparse.FileType('r'), help="CSV file containing IPFIX Information Elements specified by IANA.")
     parser.add_argument('-t', '--type-file', metavar='DATA_TYPES_CSV', type=argparse.FileType('r'), help="CSV file containing IPFIX Data Types specified by IANA.")
+    parser.add_argument('-s', '--structured-type-file', metavar='STRUCTURED_DATA_TYPES_CSV', type=argparse.FileType('r'), help="CSV file containing IPFIX Structured Data Type Semantics specified by IANA.")
     parser.add_argument('-u', '--update', action='store_true', help="Update specified IPFIX Information Elements from IANA website.")
     parser.add_argument('-d', '--directory', metavar='DIR',  help="Write to files in DIR instead of STDOUT.")
 
@@ -140,7 +152,7 @@ def main():
 
     # Update CSVs from IANA website
     if args.update:
-        args.ie_file, args.type_file = download_csvs()
+        args.ie_file, args.type_file, args.structured_type_file = download_csvs()
 
     # Default output is standard out
     out = sys.stdout
@@ -151,7 +163,7 @@ def main():
         out = open(os.path.join(args.directory, 'ipfix_iana.h'), 'w')
         struct_out = open(os.path.join(args.directory, 'ipfix_iana.c'), 'w')
 
-    generate_ipfix_output(args.ie_file, args.type_file, out, struct_out)
+    generate_ipfix_output(args.ie_file, args.type_file, args.structured_type_file, out, struct_out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds the basicList IE to the exporter side. It allows to e.g. send a list of packet length of all packets within a flow. Due to the dynamic nature and variable length of basicList, significant changes to the codebase were necessary.

See RFC 6313 for more info on basicList.

@evintila and @nickbroon please thoroughly review :)