### PR TITLE
Simplify the matrix of jobs, without having to explicitly use matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,41 +2,23 @@ language: cpp
 compiler: clang
 cache: ccache
 
-matrix:
-  include:
-    - os: linux
-      addons:
-        apt:
-          packages:
-            - cmake
-            - libboost-dev
-            - libboost-filesystem-dev
-            - libboost-regex-dev
-            - libboost-test-dev
-            - libboost-thread-dev
-            - libxml2-dev
-            - libpcap-dev
-            - libsystemd-journal-dev
-            - libsctp-dev
-      env: DTLS="NO"
-    - os: linux
-      addons:
-        apt:
-          packages:
-            - cmake
-            - libboost-dev
-            - libboost-filesystem-dev
-            - libboost-regex-dev
-            - libboost-test-dev
-            - libboost-thread-dev
-            - libxml2-dev
-            - libpcap-dev
-            - libsystemd-journal-dev
-            - libsctp-dev
-            - libssl-dev
-      env: DTLS="YES"
-  fast_finish: true
+addons:
+  apt:
+    packages:
+      - cmake
+      - libboost-dev
+      - libboost-filesystem-dev
+      - libboost-regex-dev
+      - libboost-test-dev
+      - libboost-thread-dev
+      - libxml2-dev
+      - libpcap-dev
+      - libsystemd-journal-dev
+      - libsctp-dev
+      - libssl-dev
 
-script:
-  - if [[ "$DTLS" == "NO" ]]; then cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSUPPORT_JOURNALD=ON . && make && make test; fi
-  - if [[ "$DTLS" == "YES" ]]; then cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSUPPORT_JOURNALD=ON -DSUPPORT_DTLS=YES . && make && make test; fi
+env:
+  - DTLS="ON"
+  - DTLS="OFF"
+
+script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSUPPORT_JOURNALD=ON -DSUPPORT_DTLS="$DTLS" . && make && make test


### PR DESCRIPTION
It's fine to include the package even when not used, as the compilation is explicitly controlled.