### PR TITLE
removed deprecated dynamic exception specification from Cfg

### DIFF
--- a/src/core/Cfg.cpp
+++ b/src/core/Cfg.cpp
@@ -8,7 +8,7 @@
 /**
  * internally used function
  */
-std::string CfgBase::_get(const std::string& name, XMLElement* elem) throw(IllegalEntry)
+std::string CfgBase::_get(const std::string& name, XMLElement* elem)
 {
 	if (!elem)
 		elem = _elem;

--- a/src/core/Cfg.h
+++ b/src/core/Cfg.h
@@ -94,7 +94,7 @@ public:
 	XMLElement* _elem;
 
 private:
-	std::string _get(const std::string& name, XMLElement* elem) throw(IllegalEntry);
+	std::string _get(const std::string& name, XMLElement* elem);
 };
 
 class Cfg : public CfgBase

--- a/src/modules/analysis/HostStatisticsCfg.cpp
+++ b/src/modules/analysis/HostStatisticsCfg.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "HostStatisticsCfg.h"
+#include "core/Cfg.h" // for IllegalEntry
 
 HostStatisticsCfg::HostStatisticsCfg(XMLElement* elem) : CfgHelper<HostStatistics, HostStatisticsCfg>(elem, "hostStatistics")
 {


### PR DESCRIPTION
Removed deprecated dynamic exception specification (IllegalEntry) from CfgBase::_get