### PR TITLE
fixed hiding of overloaded virtual functions

### DIFF
--- a/src/core/Destination.h
+++ b/src/core/Destination.h
@@ -34,7 +34,7 @@ public:
 
 	virtual ~Destination() { };
 	
-	virtual void receive(Emitable* e)
+	virtual void receive(NullEmitable* e)
 	{
 		THROWEXCEPTION("this module is no destination!");
 	}

--- a/src/modules/analysis/FlowLenAnalyzer.cpp
+++ b/src/modules/analysis/FlowLenAnalyzer.cpp
@@ -93,7 +93,7 @@ std::string FlowLenAnalyzer::getStatistics()
 	return "";
 }
 
-std::string FlowLenAnalyzer::getStatisticsXML()
+std::string FlowLenAnalyzer::getStatisticsXML(double interval)
 {
 	return "";
 }

--- a/src/modules/analysis/FlowLenAnalyzer.h
+++ b/src/modules/analysis/FlowLenAnalyzer.h
@@ -34,7 +34,7 @@ public:
 
 private:
 	virtual std::string getStatistics();
-	virtual std::string getStatisticsXML();
+	virtual std::string getStatisticsXML(double interval);
 
 	std::string flowFilename;
 	std::ofstream flowOutstream;


### PR DESCRIPTION
Overloaded virtual functions were hidden because of different parameter lists.
Destination<NullEmitable*> implemented receive for Emitable* instead of NullEmitable*.