### PR TITLE
More specific cmake version restriction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ PROJECT(VERMONT)
 ### CMake configuration
 
 # allow building with old CMake. Use some bundled modules as a fallback
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.4)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 
 # TODO: Once all warnings are fixed add -Werror to both of these


### PR DESCRIPTION
The latest OLD behaviour of CMP0017 CMP0003 CMP0002 was changed after
2.8.4. No need to be as strict as 3.1