### PR TITLE
Fix building with SUPPORT_DTLS=OFF and libssl-dev not installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: cpp
-compiler:
-  - clang
-  - gcc
 cache: ccache
 sudo: false
 
 addons:
   apt:
-    sources:
+    sources: &zeromq_source
     - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
       key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'
-    packages:
+    packages: &required_packages
       - cmake
       - libboost-dev
       - libboost-filesystem-dev
@@ -21,11 +18,45 @@ addons:
       - libpcap-dev
       - libsystemd-journal-dev
       - libsctp-dev
+    packages: &optional_packages
       - libssl-dev
       - libczmq-dev
 
-env:
-  - DTLS="ON" ZMQ="ON"
-  - DTLS="OFF" ZMQ="OFF"
+matrix:
+  include:
+    - compiler: gcc
+      sudo: true
+      before_install:
+        - sudo apt-get remove -qq libssl-dev
+      env: DTLS="OFF" ZMQ="OFF"
+      addons:
+        apt:
+          packages:
+            - *required_packages
+    - compiler: clang
+      sudo: true
+      before_install:
+        - sudo apt-get remove -qq libssl-dev
+      env: DTLS="OFF" ZMQ="OFF"
+      addons:
+        apt:
+          packages:
+            - *required_packages
+    - compiler: gcc
+      env: DTLS="ON" ZMQ="ON"
+      addons:
+        apt:
+          sources: *zeromq_source
+          packages:
+            - *required_packages
+            - *optional_packages
+    - compiler: clang
+      env: DTLS="ON" ZMQ="ON"
+      addons:
+        apt:
+          sources: *zeromq_source
+          packages:
+            - *required_packages
+            - *optional_packages
 
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSUPPORT_JOURNALD=ON -DSUPPORT_DTLS="$DTLS" -DSUPPORT_ZMQ="$ZMQ" . && make && make test

--- a/src/modules/ipfix/IpfixExporterCfg.cpp
+++ b/src/modules/ipfix/IpfixExporterCfg.cpp
@@ -18,7 +18,10 @@
  *
  */
 
+#include "common/ipfixlolib/ipfixlolib_config.h"
+#ifdef SUPPORT_DTLS
 #include "common/ipfixlolib/ipfixlolib_dtls.h"
+#endif
 #include "IpfixExporterCfg.h"
 
 IpfixExporterCfg::IpfixExporterCfg(XMLElement* elem)
@@ -125,12 +128,15 @@ IpfixSender* IpfixExporterCfg::createInstance()
 				p->getPort());
 #endif
 		void *aux_config = NULL;
-		ipfix_aux_config_dtls_over_udp acdou;
-		ipfix_aux_config_dtls_over_sctp acdos;
 		ipfix_aux_config_udp acu;
 		ipfix_aux_config_udp *pacu = NULL;
+#ifdef SUPPORT_DTLS
+		ipfix_aux_config_dtls_over_udp acdou;
+		ipfix_aux_config_dtls_over_sctp acdos;
 		ipfix_aux_config_dtls *pacd = NULL;
+#endif
 		switch (p->getProtocol()) {
+#ifdef SUPPORT_DTLS
 			case DTLS_OVER_UDP:
 				acdou.max_connection_lifetime = dtlsMaxConnectionLifetime;
 				pacd = &acdou.dtls;
@@ -141,6 +147,7 @@ IpfixSender* IpfixExporterCfg::createInstance()
 				pacd = &acdos.dtls;
 				aux_config = &acdos;
 				break;
+#endif
 			case UDP:
 				aux_config = &acu;
 				pacu = &acu;
@@ -148,6 +155,7 @@ IpfixSender* IpfixExporterCfg::createInstance()
 			default:
 				break;
 		}
+#ifdef SUPPORT_DTLS
 		if (pacd) {
 			pacd->peer_fqdn = NULL;
 			const std::set<std::string> peerFqdns = p->getPeerFqdns();
@@ -155,6 +163,7 @@ IpfixSender* IpfixExporterCfg::createInstance()
 			if (it != peerFqdns.end())
 				pacd->peer_fqdn = it->c_str();
 		}
+#endif
 		if (pacu) {
 			pacu->mtu = p->getMtu();
 		}


### PR DESCRIPTION
There was still some code that was unconditionally using dtls code,
which requires ssl. This has now been made conditional.

I suspect this is indicative of code smell here, and that perhaps
better encapsulation is needed around this. But that come later as
more attempts are made to modularise the code.

Fixes #85