### PR TITLE
replaced the exception in the destructor with a msg

### DIFF
--- a/src/modules/ipfix/IpfixPrinter.cpp
+++ b/src/modules/ipfix/IpfixPrinter.cpp
@@ -389,7 +389,7 @@ IpfixPrinter::~IpfixPrinter()
 	if (filename != "") {
 		int ret = fclose(fh);
 		if (ret)
-			THROWEXCEPTION("IpfixPrinter: error closing file '%s': %s (%u)", filename.c_str(), strerror(errno), errno);
+			msg(MSG_ERROR, "IpfixPrinter: error closing file '%s': %s (%u)", filename.c_str(), strerror(errno), errno);
 	}
 }
 


### PR DESCRIPTION
Exceptions are not to be thrown from destructors.
Normally I would have moved the closing of the file in a separate method, but calling it messes up the design (needs specialization of the CfgHelper template class). Instead, an error message is displayed -- aborting seems to drastic in this case.