### PR TITLE
Add vagrant VM with automatic vermont setup

### DIFF
--- a/dev/README
+++ b/dev/README
@@ -1,0 +1,8 @@
+Install Vagrant and Ansible each with version >= 2.0
+Then, in this folder
+$ vagrant up
+...wait...
+$ vagrant ssh
+# cd /vermont
+
+Here you find the vermont executable and the necessary config files under configs/

--- a/dev/README
+++ b/dev/README
@@ -1,8 +1,0 @@
-Install Vagrant and Ansible each with version >= 2.0
-Then, in this folder
-$ vagrant up
-...wait...
-$ vagrant ssh
-# cd /vermont
-
-Here you find the vermont executable and the necessary config files under configs/

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,25 @@
+# VERMONT VM
+
+This vagrant setup provides an entry point for directly testing vermont without
+further setup on a local machine.
+
+It creates a VM which automatically installs all necessary dependecies for
+vermont and builds the currently checked out version of it.
+The repository is available in the VM via /vermont
+
+## Setup
+
+Install Vagrant and Ansible each with version >= 2.0.
+Then, in this folder
+
+``` shell
+$ vagrant up
+...wait...
+$ vagrant ssh
+# cd /vermont
+# ./vermont -f <config-file>
+```
+## Build Configuration
+
+The build process, its steps and parameters  can be configured in
+roles/base/tasks/main.yml

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -3,12 +3,12 @@
 
 Vagrant.configure("2") do |config|
   config.vm.hostname = "vermont"
-  config.vm.box = "trusty_amd"
-  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "debian/contrib-jessie64"
+  config.vm.box_url = "https://app.vagrantup.com/debian/boxes/contrib-jessie64"
   config.vm.network "private_network", ip: "192.168.50.4"
   config.vm.synced_folder  "../",  "/vermont"
 
-  config.vm.provision "shell", inline: "apt-get install python3"   # For ansible to function
+  config.vm.provision "shell", inline: "apt-get -y install python3"   # For ansible to function
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"
     ansible.extra_vars = {  ansible_python_interpreter: "/usr/bin/python3" }

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -1,0 +1,16 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.hostname = "vermont"
+  config.vm.box = "trusty_amd"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.network "private_network", ip: "192.168.50.4"
+  config.vm.synced_folder  "../",  "/vermont"
+
+  config.vm.provision "shell", inline: "apt-get install python3"   # For ansible to function
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "playbook.yml"
+    ansible.extra_vars = {  ansible_python_interpreter: "/usr/bin/python3" }
+  end
+end

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "vermont"
   config.vm.box = "debian/contrib-jessie64"
   config.vm.box_url = "https://app.vagrantup.com/debian/boxes/contrib-jessie64"
-  config.vm.network "private_network", ip: "192.168.50.4"
+  config.vm.network "public_network"
   config.vm.synced_folder  "../",  "/vermont"
 
   config.vm.provision "shell", inline: "apt-get -y install python3"   # For ansible to function

--- a/dev/playbook.yml
+++ b/dev/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  become_user: root
+  become: true
+  roles:
+    - base

--- a/dev/roles/base/tasks/main.yml
+++ b/dev/roles/base/tasks/main.yml
@@ -10,8 +10,8 @@
     state: present
     filename: 'mq'
 
-- name: Add toolchain
-  apt_repository: repo='ppa:ubuntu-toolchain-r/test'
+    #- name: Add toolchain
+    #  apt_repository: repo='ppa:ubuntu-toolchain-r/test'
 
 - name: install dependencies
   apt: name={{item}} state=present install_recommends=no update_cache=yes
@@ -29,17 +29,22 @@
     - libsctp-dev
     - libssl-dev
     - libczmq-dev
-    - g++-7
+    - g++
+
+- name: create build directory
+  command: mkdir -p build-vagrant
+  args:
+    chdir: /vermont
 
 - name: cmake vermont
   command: "{{item}}"
   with_items:
-    - cmake -DCMAKE_INSTALL_PREFIX=/tmp -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSUPPORT_JOURNALD=ON -DSUPPORT_DTLS=ON -DSUPPORT_ZMQ=ON .
+    - cmake -DCMAKE_INSTALL_PREFIX=/tmp -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSUPPORT_JOURNALD=ON -DSUPPORT_DTLS=ON -DSUPPORT_ZMQ=ON ..
     - make -k
     - make test
     - make install
   environment:
-    CXX: g++-7
-    CC: gcc-7
+    CXX: g++
+    CC: gcc
   args:
-    chdir: /vermont
+    chdir: /vermont/build-vagrant

--- a/dev/roles/base/tasks/main.yml
+++ b/dev/roles/base/tasks/main.yml
@@ -1,0 +1,45 @@
+
+- name: Add ZMQ key
+  apt_key:
+    url: http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key
+    state: present
+
+- name: Add ZMQ ppa
+  apt_repository:
+    repo: deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./
+    state: present
+    filename: 'mq'
+
+- name: Add toolchain
+  apt_repository: repo='ppa:ubuntu-toolchain-r/test'
+
+- name: install dependencies
+  apt: name={{item}} state=present install_recommends=no update_cache=yes
+  with_items:
+    - cmake
+    - pkg-config
+    - libboost-dev
+    - libboost-filesystem-dev
+    - libboost-regex-dev
+    - libboost-test-dev
+    - libboost-thread-dev
+    - libxml2-dev
+    - libpcap-dev
+    - libsystemd-journal-dev
+    - libsctp-dev
+    - libssl-dev
+    - libczmq-dev
+    - g++-7
+
+- name: cmake vermont
+  command: "{{item}}"
+  with_items:
+    - cmake -DCMAKE_INSTALL_PREFIX=/tmp -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSUPPORT_JOURNALD=ON -DSUPPORT_DTLS=ON -DSUPPORT_ZMQ=ON .
+    - make -k
+    - make test
+    - make install
+  environment:
+    CXX: g++-7
+    CC: gcc-7
+  args:
+    chdir: /vermont

--- a/dev/roles/base/tasks/main.yml
+++ b/dev/roles/base/tasks/main.yml
@@ -16,6 +16,7 @@
 - name: install dependencies
   apt: name={{item}} state=present install_recommends=no update_cache=yes
   with_items:
+    - ntp
     - cmake
     - pkg-config
     - libboost-dev
@@ -31,10 +32,11 @@
     - libczmq-dev
     - g++
 
+- name: remove build directory
+  file: path='/vermont/build-vagrant/' state=absent
+
 - name: create build directory
-  command: mkdir -p build-vagrant
-  args:
-    chdir: /vermont
+  file: path='/vermont/build-vagrant' state=directory
 
 - name: cmake vermont
   command: "{{item}}"
@@ -47,4 +49,4 @@
     CXX: g++
     CC: gcc
   args:
-    chdir: /vermont/build-vagrant
+    chdir: /vermont/build-vagrant/

--- a/dev/roles/base/tasks/main.yml
+++ b/dev/roles/base/tasks/main.yml
@@ -1,12 +1,12 @@
 
 - name: Add ZMQ key
   apt_key:
-    url: http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key
+    url: http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_8.0/Release.key
     state: present
 
 - name: Add ZMQ ppa
   apt_repository:
-    repo: deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./
+    repo: deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_8.0/ ./
     state: present
     filename: 'mq'
 


### PR DESCRIPTION
Provides a vagrant setup where dependencies for vermont are automatically installed and vermont is build. 
After starting and provisioning the VM, vermont can be directly tested inside this VM. 