### PR TITLE
Correct output the protocol as a string

### DIFF
--- a/src/modules/ipfix/IpfixRecord.hpp
+++ b/src/modules/ipfix/IpfixRecord.hpp
@@ -197,7 +197,7 @@ class IpfixRecord
 						oss << " (SCTP)";
 						break;
 					default:
-						oss << " (" << protocol <<")";
+						oss << " (" << std::to_string(protocol) <<")";
 						break;
 				}
 				oss << " ODID=" << observationDomainId;
@@ -390,4 +390,3 @@ class IpfixTemplateDestructionRecord : public IpfixRecord, public ManagedInstanc
 
 
 #endif
-


### PR DESCRIPTION
stringstream treats uint8_t as a char which in some cases may be
unprintable ascii (eg 255 might be the protocol), so explicitly print
it as a string so it can be read.