### PR TITLE
Don't leak the xmlString in Cfg

### DIFF
--- a/src/core/XMLNode.cpp
+++ b/src/core/XMLNode.cpp
@@ -22,7 +22,10 @@ std::string XMLNode::getName() const
 
 const std::string XMLNode::getContent() const
 {
-	return std::string((const char*)xmlNodeGetContent(xmlNode));
+	xmlChar *xmlString = xmlNodeGetContent(xmlNode);
+	std::string string ((const char*)xmlString);
+	xmlFree(xmlString);
+	return string;
 }
 
 XMLNode::XMLNodeSet XMLNode::findChildren(const std::string& name)

--- a/src/modules/ConfigManager.cpp
+++ b/src/modules/ConfigManager.cpp
@@ -120,6 +120,9 @@ ConfigManager::~ConfigManager()
 	if (graph) {
 		delete graph;
 	}
+	if (document) {
+		delete document;
+	}
 }
 
 /**
@@ -330,4 +333,3 @@ Graph* ConfigManager::reconnect(Graph* g, Graph *old)
 
 	return newGraph;
 }
-


### PR DESCRIPTION
Valgrind was reporting lots of leaks of the form:

```
==5048==    at 0x4C2BBAF: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5048==    by 0x5D50D18: xmlBufCreateSize (in /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.4)
==5048==    by 0x5CDDD91: xmlNodeGetContent (in /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.4)
==5048==    by 0x38EB01: XMLNode::getContent[abi:cxx11]() const (in /usr/sbin/vermont)
==5048==    by 0x285B62: CollectorCfg::CollectorCfg(XMLElement*, unsigned int) (in /usr/sbin/vermont)
```

The API guide for xmlNodeGetContent() states:

Returns: a new #xmlChar * or NULL if no content is available. It's up to the caller to free the memory with xmlFree().

So call xmlFree() after using the std:string copy constructor

Fixes #117