### PR TITLE
Additional compiler builds for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -199,6 +199,18 @@ matrix:
             - *required_packages
             - *optional_packages
             - clang-7
+    # - stage: Static Analysis
+    #   env:
+    #     - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+    #   addons:
+    #     apt:
+    #       sources: *zeromq_source_and_toolchain_clang_7
+    #       packages:
+    #         - *required_packages
+    #         - *optional_packages
+    #         - clang-7
+    #         - clang-tools-7
+    #   script: scan-build --status-bugs cmake -DCMAKE_INSTALL_PREFIX=/tmp -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DSUPPORT_JOURNALD=ON -DSUPPORT_DTLS="$DTLS" -DSUPPORT_ZMQ="$ZMQ" . && scan-build --status-bugs make -k
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,16 @@ addons:
       - llvm-toolchain-trusty-5.0
       - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
         key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'      
+    sources: &zeromq_source_and_toolchain_clang_6-0
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-6.0
+      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
+        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'
+    sources: &zeromq_source_and_toolchain_clang_7
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-7
+      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
+        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'
     packages: &required_packages
       - cmake
       - libboost-dev
@@ -159,7 +169,27 @@ matrix:
             - *required_packages
             - *optional_packages
             - clang-5.0
-            
+    - compiler: clang-6.0
+      env:
+        - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+      addons:
+        apt:
+          sources: *zeromq_source_and_toolchain_clang_6-0
+          packages:
+            - *required_packages
+            - *optional_packages
+            - clang-6.0
+    - compiler: clang-7
+      env:
+        - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+      addons:
+        apt:
+          sources: *zeromq_source_and_toolchain_clang_7
+          packages:
+            - *required_packages
+            - *optional_packages
+            - clang-7
+
 before_install:
   - eval "${MATRIX_EVAL}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,16 @@ matrix:
             - *required_packages
             - *optional_packages
             - g++-7
+    # - compiler: gcc-8
+    #   env:
+    #     - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=gcc-8 CXX=g++-8"
+    #   addons:
+    #     apt:
+    #       sources: *zeromq_source_and_toolchain_gcc
+    #       packages:
+    #         - *required_packages
+    #         - *optional_packages
+    #         - g++-8
 
     - compiler: clang
       env:

--- a/src/common/msg.h
+++ b/src/common/msg.h
@@ -53,8 +53,20 @@ void msg_set_syslog(bool);
 bool msg_get_syslog();
 int msg_stat(const char *fmt, ...);
 int msg_stat_setup(int mode, FILE *f);
-void vermont_assert(const char* expr, const char* description, int line, const char* filename, const char* prettyfuncname, const char* funcname);
-void vermont_exception(const int, const char*, const char*, const char*, const char*, ...);
+
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+#ifndef CLANG_ANALYZER_NORETURN
+#if __has_feature(attribute_analyzer_noreturn)
+#define CLANG_ANALYZER_NORETURN __attribute__((analyzer_noreturn))
+#else
+#define CLANG_ANALYZER_NORETURN
+#endif
+#endif
+
+void vermont_assert(const char* expr, const char* description, int line, const char* filename, const char* prettyfuncname, const char* funcname) __attribute__((__noreturn__));
+void vermont_exception(const int, const char*, const char*, const char*, const char*, ...) CLANG_ANALYZER_NORETURN;
 
 //#if !defined(__PRETTY_FUNCTION__)
 	//#define __PRETTY_FUNCTION__ "<unknown>"


### PR DESCRIPTION
Newer clang compilers all build just fine. gcc 8 fails to build, mainly in the XML code, that will need fixing.
scan-build example stage that shows static analysis errors that could be tackled.
Small code attributes to make the scan-build output less verbose.