### PR TITLE
Add a logging attribute to the ipfix config element

### DIFF
--- a/configs/simple.xml
+++ b/configs/simple.xml
@@ -1,4 +1,4 @@
-<ipfixConfig>
+<ipfixConfig logging="info">
 	<observer id="1">
 		<interface>en0</interface>
 		<pcap_filter>ip</pcap_filter>

--- a/src/common/msg.cc
+++ b/src/common/msg.cc
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <pthread.h>
+#include <sys/syslog.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/time.h>
@@ -64,6 +65,36 @@ extern "C" {
 		default:
 			return "UNKNOWN";
 		}
+	}
+
+	/**
+	 * @brief parse a string and return a logging bitmask
+	 *
+	 * @param arg string represent logging level
+	 * @return bitmask of logging levels up to arg
+	 * @return -1 if logging level is not recognised
+	 */
+	int
+	parse_log_level (const char *arg)
+	{
+		if (!strcmp("debug", arg)) {
+			return LOG_UPTO(LOG_DEBUG);
+		} else if (!strcmp("info", arg)) {
+			return LOG_UPTO(LOG_INFO);
+		} else if (!strcmp("notice", arg)) {
+			return LOG_UPTO(LOG_NOTICE);
+		} else if (!strcmp("warning", arg)) {
+			return LOG_UPTO(LOG_WARNING);
+		} else if (!strcmp("err", arg)) {
+			return LOG_UPTO(LOG_ERR);
+		} else if (!strcmp("crit", arg)) {
+			return LOG_UPTO(LOG_CRIT);
+		} else if (!strcmp("alert", arg)) {
+			return LOG_UPTO(LOG_ALERT);
+		} else if (!strcmp("emerg", arg)) {
+			return LOG_UPTO(LOG_EMERG);
+		}
+		return -1;
 	}
 
 	/**

--- a/src/common/msg.h
+++ b/src/common/msg.h
@@ -45,6 +45,7 @@ typedef void (*LOGFUNCTION)(void *);
 void msg_init(void);
 void msg_shutdown(void);
 void msg2(const int, const char*, const char*, const char*, const int, const char *, ...);
+int parse_log_level (const char *arg);
 void msg_setlevel(int);
 int msg_getlevel();
 void msg_setquiet(bool);

--- a/src/modules/ConfigManager.cpp
+++ b/src/modules/ConfigManager.cpp
@@ -152,6 +152,19 @@ void ConfigManager::parseConfig(std::string fileName)
 			       " This is not a valid configuration file!");
 	}
 
+	XMLAttribute* logging_attribute = root->getAttribute("logging");
+	if (logging_attribute) {
+		int log_bitask = parse_log_level(logging_attribute->getValue().c_str());
+		if (log_bitask == -1) {
+			msg(LOG_CRIT, "ignoring unknown log level '%s'",
+			    logging_attribute->getValue().c_str());
+		} else {
+			msg(LOG_NOTICE, "setting log level '%s'",
+			    logging_attribute->getValue().c_str());
+			msg_setlevel(log_bitask);
+		}
+	}
+
 	/* process each root element node and add a new node (with its config
 	 * attached to the node) to the graph
 	 */

--- a/src/tests/vermonttest/ConfigTester.cpp
+++ b/src/tests/vermonttest/ConfigTester.cpp
@@ -43,7 +43,7 @@ Test::TestResult ConfigTester::execTest()
 
 void ConfigTester::testConfig(const std::string& configFile)
 {
-	std::string vermontCommand = "../../../vermont -ddddd -f test_configs/" + configFile;
+	std::string vermontCommand = "../../../vermont -l debug -f test_configs/" + configFile;
 
 	std::string generatedOutput = "gen_output/" + configFile;
 	std::string expectedOutput = "exp_output/" + configFile;


### PR DESCRIPTION
This allows the logging level to set as part of configuration, instead
of having to use the `-l` CLI option. This mean it can also be changed
dynamically when the config file is re-read for changes.