### PR TITLE
Fix Travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,39 +5,22 @@ sudo: false
 addons:
   apt:
     sources: &zeromq_source
-      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
-        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key' 
+      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/ ./'
+        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/Release.key' 
     sources: &zeromq_source_and_toolchain_gcc
       - ubuntu-toolchain-r-test
-      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
-        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'     
-    sources: &zeromq_source_and_toolchain_clang_3-8
-      - llvm-toolchain-trusty-3.8
-      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
-        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'      
-    sources: &zeromq_source_and_toolchain_clang_4-0
-      - llvm-toolchain-trusty-4.0
-      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
-        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'      
-    sources: &zeromq_source_and_toolchain_clang_5-0
-      - llvm-toolchain-trusty-5.0
-      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
-        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'      
-    sources: &zeromq_source_and_toolchain_clang_6-0
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-6.0
-      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
-        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'
+      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/ ./'
+        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/Release.key'     
     sources: &zeromq_source_and_toolchain_clang_7
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-7
-      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
-        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'
+      - llvm-toolchain-xenial-7
+      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/ ./'
+        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/Release.key'
     sources: &zeromq_source_and_toolchain_clang_8
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-8
-      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./'
-        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key'
+      - llvm-toolchain-xenial-8
+      - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/ ./'
+        key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/Release.key'
     packages: &required_packages
       - cmake
       - libboost-dev
@@ -47,7 +30,7 @@ addons:
       - libboost-thread-dev
       - libxml2-dev
       - libpcap-dev
-      - libsystemd-journal-dev
+      - libsystemd-dev
       - libsctp-dev
     packages: &optional_packages
       - libssl-dev
@@ -95,16 +78,6 @@ matrix:
           packages:
             - *required_packages
             - *optional_packages
-    - compiler: gcc-5
-      env:
-        - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=gcc-5 CXX=g++-5"
-      addons:
-        apt:
-          sources: *zeromq_source_and_toolchain_gcc
-          packages:
-            - *required_packages
-            - *optional_packages
-            - g++-5
     - compiler: gcc-6
       env:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=gcc-6 CXX=g++-6"
@@ -154,22 +127,12 @@ matrix:
           packages:
             - *required_packages
             - *optional_packages
-    - compiler: clang-3.8
-      env:
-        - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
-      addons:
-        apt:
-          sources: *zeromq_source_and_toolchain_clang_3-8
-          packages:
-            - *required_packages
-            - *optional_packages
-            - clang-3.8
     - compiler: clang-4.0
       env:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
       addons:
         apt:
-          sources: *zeromq_source_and_toolchain_clang_4-0
+          sources: *zeromq_source
           packages:
             - *required_packages
             - *optional_packages
@@ -179,7 +142,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
       addons:
         apt:
-          sources: *zeromq_source_and_toolchain_clang_5-0
+          sources: *zeromq_source
           packages:
             - *required_packages
             - *optional_packages
@@ -189,7 +152,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
       addons:
         apt:
-          sources: *zeromq_source_and_toolchain_clang_6-0
+          sources: *zeromq_source
           packages:
             - *required_packages
             - *optional_packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,30 +4,32 @@ sudo: false
 
 addons:
   apt:
-    sources: &zeromq_source
+    sources: &boost_source
+      - sourceline: 'ppa:mhier/libboost-latest'
+    sources: &boost_source_and_zeromq_source
+      - sourceline: 'ppa:mhier/libboost-latest'
       - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/ ./'
         key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/Release.key' 
-    sources: &zeromq_source_and_toolchain_gcc
+    sources: &boost_source_and_zeromq_source_and_toolchain_gcc
       - ubuntu-toolchain-r-test
+      - sourceline: 'ppa:mhier/libboost-latest'
       - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/ ./'
         key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/Release.key'     
-    sources: &zeromq_source_and_toolchain_clang_7
+    sources: &boost_source_and_zeromq_source_and_toolchain_clang_7
       - ubuntu-toolchain-r-test
       - llvm-toolchain-xenial-7
+      - sourceline: 'ppa:mhier/libboost-latest'
       - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/ ./'
         key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/Release.key'
-    sources: &zeromq_source_and_toolchain_clang_8
+    sources: &boost_source_and_zeromq_source_and_toolchain_clang_8
       - ubuntu-toolchain-r-test
       - llvm-toolchain-xenial-8
+      - sourceline: 'ppa:mhier/libboost-latest'
       - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/ ./'
         key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_16.04/Release.key'
     packages: &required_packages
       - cmake
-      - libboost-dev
-      - libboost-filesystem-dev
-      - libboost-regex-dev
-      - libboost-test-dev
-      - libboost-thread-dev
+      - libboost1.70-dev
       - libxml2-dev
       - libpcap-dev
       - libsystemd-dev
@@ -46,6 +48,7 @@ matrix:
         - DTLS="OFF" ZMQ="OFF" BUILD_TYPE="RelWithDebInfo"
       addons:
         apt:
+          sources: *boost_source
           packages:
             - *required_packages
             
@@ -57,6 +60,7 @@ matrix:
         - DTLS="OFF" ZMQ="OFF" BUILD_TYPE="RelWithDebInfo"
       addons:
         apt:
+          sources: *boost_source
           packages:
             - *required_packages
  
@@ -65,7 +69,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo"
       addons:
         apt:
-          sources: *zeromq_source
+          sources: *boost_source_and_zeromq_source
           packages:
             - *required_packages
             - *optional_packages
@@ -74,7 +78,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="Debug"
       addons:
         apt:
-          sources: *zeromq_source
+          sources: *boost_source_and_zeromq_source
           packages:
             - *required_packages
             - *optional_packages
@@ -83,7 +87,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=gcc-6 CXX=g++-6"
       addons:
         apt:
-          sources: *zeromq_source_and_toolchain_gcc
+          sources: *boost_source_and_zeromq_source_and_toolchain_gcc
           packages:
             - *required_packages
             - *optional_packages
@@ -93,7 +97,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=gcc-7 CXX=g++-7"
       addons:
         apt:
-          sources: *zeromq_source_and_toolchain_gcc
+          sources: *boost_source_and_zeromq_source_and_toolchain_gcc
           packages:
             - *required_packages
             - *optional_packages
@@ -103,7 +107,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=gcc-8 CXX=g++-8"
       addons:
         apt:
-          sources: *zeromq_source_and_toolchain_gcc
+          sources: *boost_source_and_zeromq_source_and_toolchain_gcc
           packages:
             - *required_packages
             - *optional_packages
@@ -114,7 +118,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo"
       addons:
         apt:
-          sources: *zeromq_source
+          sources: *boost_source_and_zeromq_source
           packages:
             - *required_packages
             - *optional_packages
@@ -123,7 +127,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="Debug"
       addons:
         apt:
-          sources: *zeromq_source
+          sources: *boost_source_and_zeromq_source
           packages:
             - *required_packages
             - *optional_packages
@@ -132,7 +136,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
       addons:
         apt:
-          sources: *zeromq_source
+          sources: *boost_source_and_zeromq_source
           packages:
             - *required_packages
             - *optional_packages
@@ -142,7 +146,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
       addons:
         apt:
-          sources: *zeromq_source
+          sources: *boost_source_and_zeromq_source
           packages:
             - *required_packages
             - *optional_packages
@@ -152,7 +156,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
       addons:
         apt:
-          sources: *zeromq_source
+          sources: *boost_source_and_zeromq_source
           packages:
             - *required_packages
             - *optional_packages
@@ -162,7 +166,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
       addons:
         apt:
-          sources: *zeromq_source_and_toolchain_clang_7
+          sources: *boost_source_and_zeromq_source_and_toolchain_clang_7
           packages:
             - *required_packages
             - *optional_packages
@@ -172,7 +176,7 @@ matrix:
         - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
       addons:
         apt:
-          sources: *zeromq_source_and_toolchain_clang_8
+          sources: *boost_source_and_zeromq_source_and_toolchain_clang_8
           packages:
             - *required_packages
             - *optional_packages
@@ -182,7 +186,9 @@ matrix:
     #     - DTLS="ON" ZMQ="ON" BUILD_TYPE="RelWithDebInfo" MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
     #   addons:
     #     apt:
-    #       sources: *zeromq_source_and_toolchain_clang_7
+    #       sources:
+    #         - *boost_source_and_zeromq_source_and_toolchain_clang_7
+    #         - *boost_source
     #       packages:
     #         - *required_packages
     #         - *optional_packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,4 +193,4 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}"
 
-script: cmake -DCMAKE_INSTALL_PREFIX=/tmp -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DSUPPORT_JOURNALD=ON -DSUPPORT_DTLS="$DTLS" -DSUPPORT_ZMQ="$ZMQ" . && make -k && make test && make install
+script: cmake -DCMAKE_INSTALL_PREFIX=/tmp -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DSUPPORT_JOURNALD=ON -DSUPPORT_DTLS="$DTLS" -DSUPPORT_ZMQ="$ZMQ" . && make -k VERBOSE=1 && make -k VERBOSE=1 test && make VERBOSE=1 install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,46 +234,24 @@ ENDIF (HIREDIS_FOUND)
 
 ### boost
 
-FIND_PACKAGE(Boost REQUIRED)
-MARK_AS_ADVANCED(
-	Boost_INCLUDE_DIR
-	Boost_REGEX_LIBRARY
-  Boost_THREAD_LIBRARY
-	Boost_FILESYSTEM_LIBRARY
-	Boost_UNIT_TEST_FRAMEWORK_LIBRARY
-)
+FIND_PACKAGE(Boost REQUIRED COMPONENTS
+                regex
+                thread
+                filesystem
+                unit_test_framework
+                system)
+
 IF (Boost_FOUND)
 	MESSAGE(STATUS "Found boost libraries")
 	ADD_DEFINITIONS(-DHAVE_BOOST_FILESYSTEM)
 	INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
-	FIND_LIBRARY(Boost_REGEX_LIBRARY NAMES boost_regex-mt boost_regex PATHS ${Boost_LIBRARY_DIRS})
-	IF (NOT Boost_REGEX_LIBRARY)
-		MESSAGE(FATAL_ERROR "Could not find boost regex library")
-	ENDIF(NOT Boost_REGEX_LIBRARY)
-  FIND_LIBRARY(Boost_THREAD_LIBRARY NAMES boost_thread-mt boost_thread PATHS ${Boost_LIBRARY_DIRS})
-  IF (NOT Boost_THREAD_LIBRARY)
-		MESSAGE(FATAL_ERROR "Could not find boost thread library")
-  ENDIF(NOT Boost_THREAD_LIBRARY)
-  FIND_LIBRARY(Boost_FILESYSTEM_LIBRARY NAMES boost_filesystem-mt boost_filesystem PATHS ${Boost_LIBRARY_DIRS})
-	IF (NOT Boost_FILESYSTEM_LIBRARY)
-		MESSAGE(FATAL_ERROR "Could not find boost filesystem library")
-	ENDIF(NOT Boost_FILESYSTEM_LIBRARY)
-	FIND_LIBRARY(Boost_UNIT_TEST_FRAMEWORK_LIBRARY NAMES boost_unit_test_framework-mt boost_unit_test_framework PATHS ${Boost_LIBRARY_DIRS})
-	IF (NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY)
-		MESSAGE(FATAL_ERROR "Could not find boost unit test framework")
-	ENDIF (NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY)
-	FIND_LIBRARY(Boost_SYSTEM_LIBRARY NAMES boost_system-mt boost_system PATHS ${Boost_LIBRARY_DIRS})
-	IF (NOT Boost_SYSTEM_LIBRARY)
-		MESSAGE(FATAL_ERROR "Could not find boost system library")
-	ENDIF (NOT Boost_SYSTEM_LIBRARY)
 	TARGET_LINK_LIBRARIES(vermont
-		${Boost_REGEX_LIBRARY}
-		${Boost_FILESYSTEM_LIBRARY}
-		${Boost_SYSTEM_LIBRARY}
+		Boost::regex
+		Boost::filesystem
+		Boost::system
 	)
   IF (SUPPORT_MONGO) 
-	  TARGET_LINK_LIBRARIES(vermont
-		  ${Boost_THREAD_LIBRARY}
+	  TARGET_LINK_LIBRARIES(vermont Boost::thread
     )
   ENDIF (SUPPORT_MONGO)
 

--- a/src/tests/vermonttest/CMakeLists.txt
+++ b/src/tests/vermonttest/CMakeLists.txt
@@ -36,9 +36,9 @@ TARGET_LINK_LIBRARIES(vermonttest
         common        
         osdep      
 	${CMAKE_THREAD_LIBS_INIT}
-	${Boost_REGEX_LIBRARY}
-	${Boost_FILESYSTEM_LIBRARY}
-	${Boost_SYSTEM_LIBRARY}
+	Boost::regex
+	Boost::filesystem
+	Boost::system
 	${PCAP_LIBRARY}
 	${LIBXML2_LIBRARIES}
 )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -27,9 +27,9 @@ TARGET_LINK_LIBRARIES(testCollector
 	ipfixlolib
 	common
 	osdep
-	${Boost_REGEX_LIBRARY}
-	${Boost_FILESYSTEM_LIBRARY}
-	${Boost_SYSTEM_LIBRARY}
+	Boost::regex
+	Boost::filesystem
+	Boost::system
 	${CMAKE_THREAD_LIBS_INIT}
 	${PCAP_LIBRARY}
 )


### PR DESCRIPTION
Travis was updated to use Ubuntu Xenial instead Trusty, see https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment, which broke all the current vermont travis builds.

This fix update the Travis file to deal with move to Xenial. Instead of all the builds failing, only the gcc 6,7,8 builds are now failing. (These appear to be due to complex interaction between the ABI difference in these compilers compared to the that used to build the boost library when using C11++, and will require further investigation.)

Fixes #128 