### PR TITLE
Use a wiki remote that exists

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/wiki"]
 	path = docs/wiki
-	url = git://github.com/constcast/vermont.wiki.git
+	url = git://github.com/tumi8/vermont.wiki.git


### PR DESCRIPTION
Looks like @constcast constcast wiki repo has fallen off the internet :

fatal: remote error: access denied or repository not exported: /a/nw/ad/0c/93/1421452/254611723.wiki.git
fatal: clone of 'git://github.com/constcast/vermont.wiki.git' into submodule path '/Users/Nick/Software/vermont/docs/wiki' failed

Probably best to use tumi8 as that's the definitive uptream anyway.