### PR TITLE
Fix for parseProtoInformation

### DIFF
--- a/src/modules/ipfix/aggregator/Rules.cpp
+++ b/src/modules/ipfix/aggregator/Rules.cpp
@@ -111,7 +111,7 @@ int parseModifier(const char* s, Rule::Field::Modifier* modifier) {
  * parses the given string
  * @return 0 if successful
  */
-int parseProtoPattern(char* s, IpfixRecord::Data** fdata, InformationElement::IeLength* length) {
+int parseProtoPattern(const char* s, IpfixRecord::Data** fdata, InformationElement::IeLength* length) {
 	int proto = -1;
 	if (strcmp(s, "ICMP") == 0) proto = IPFIX_protocolIdentifier_ICMP;
 	if (strcmp(s, "TCP") == 0) proto = IPFIX_protocolIdentifier_TCP;
@@ -121,8 +121,10 @@ int parseProtoPattern(char* s, IpfixRecord::Data** fdata, InformationElement::Ie
 
 	if (proto == -1)
 	{
-		proto = atoi(s);
-		if((proto < 0) || (proto > 255)) return -1;
+		char* end;
+		errno = 0;
+		proto = strtol(s, &end, 10);
+		if(end == s || *end != 0 || errno != 0 || (proto < 0) || (proto > 255)) return -1;
 	}
 
 	*length = 1;

--- a/src/modules/ipfix/aggregator/Rules.cpp
+++ b/src/modules/ipfix/aggregator/Rules.cpp
@@ -122,7 +122,7 @@ int parseProtoPattern(char* s, IpfixRecord::Data** fdata, InformationElement::Ie
 	if (proto == -1)
 	{
 		proto = atoi(s);
-		if((proto < 0) && (proto > 255)) return -1;
+		if((proto < 0) || (proto > 255)) return -1;
 	}
 
 	*length = 1;

--- a/src/modules/ipfix/aggregator/Rules.hpp
+++ b/src/modules/ipfix/aggregator/Rules.hpp
@@ -45,7 +45,7 @@ class Rules {
 };
 
 int parseModifier(const char* s, Rule::Field::Modifier* modifier);
-int parseProtoPattern(char* s, IpfixRecord::Data** fdata, InformationElement::IeLength* length);
+int parseProtoPattern(const char* s, IpfixRecord::Data** fdata, InformationElement::IeLength* length);
 int parseIPv4Pattern(char* s, IpfixRecord::Data** fdata, InformationElement::IeLength* length);
 int parsePortPattern(char* s, IpfixRecord::Data** fdata, InformationElement::IeLength* length);
 int parseTcpFlags(char* s, IpfixRecord::Data** fdata, InformationElement::IeLength* length);

--- a/src/tests/ipfixlolib/CMakeLists.txt
+++ b/src/tests/ipfixlolib/CMakeLists.txt
@@ -56,3 +56,4 @@ IF (JOURNALD_FOUND)
 ENDIF (JOURNALD_FOUND)
 
 ADD_TEST(example_2 example_code_2)
+ADD_TEST(mtutest mtutest)

--- a/src/tests/vermonttest/ConfigTester.h
+++ b/src/tests/vermonttest/ConfigTester.h
@@ -14,6 +14,7 @@ public:
 	virtual TestResult execTest();
 
 private:
+	void test_Rules_parseProtoPattern();
 	void testConfig(const std::string& configFile);
 	std::vector<std::string> configFiles;
 };

--- a/src/tests/vermonttest/VermontTest.cpp
+++ b/src/tests/vermonttest/VermontTest.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
 	testSuite.add(new BloomFilterTestSuite());
 	testSuite.add(new ConnectionFilterTestSuite());
 #endif
-	//testSuite.add(new ConfigTester());
+	testSuite.add(new ConfigTester());
 
 	testSuite.run();
 


### PR DESCRIPTION
This pull requests addresses two issues and introduces another change:

- Build errors on clang10, which identifies a logic bug
- Invalid values for the match field for protocolIdentifier result in errors (fixes #134 )
- Runs vermonttest during travis builds