### PR TITLE
Fixed compile error when using the IpfixDbWriter

### DIFF
--- a/src/modules/ipfix/database/IpfixDbWriterSQL.cpp
+++ b/src/modules/ipfix/database/IpfixDbWriterSQL.cpp
@@ -777,8 +777,8 @@ IpfixDbWriterSQL::IpfixDbWriterSQL(const char* dbtype, const char* host, const c
 	for(vector<string>::const_iterator col = columns.begin(); col != columns.end(); col++) {
 		std::string columnName = *col;
 		std::string dataType = "";
-		uint16_t ipfixId;
-		uint32_t enterpriseId;
+		uint16_t ipfixId = 0;
+		uint32_t enterpriseId = 0;
 		if (useLegacyNames) {
 			bool found = false;
 			int i = 0;


### PR DESCRIPTION
This PR adds default values for two variables, `ipfixId` and `enterpriseId`, in the `IpfixDbWriterSQL` class. Usually, these variables will always be set or an exception will be thrown, but gcc (tested with gcc 8.3.0 on debian) doesn't see this and will fail to compile due to `-Werror`. This commit fixes the issue by setting both variables to zero at initialization.

In case you need reproduction steps for the initial error:
- Use a fresh Debian 10 install and install all dependencies including libpg
- Execute `cmake -DSUPPORT_POSTGRESQL=True -DCMAKE_BUILD_TYPE=Release . && make`

This results in the following error:
```
[ 90%] Building CXX object src/modules/CMakeFiles/modules.dir/ipfix/database/IpfixDbWriterPg.cpp.o
/root/vermont-git/src/modules/ipfix/database/IpfixDbWriterSQL.cpp: In constructor ‘IpfixDbWriterSQL::IpfixDbWriterSQL(const char*, const char*, const char*, const char*, const char*, unsigned int, uint16_t, int, std::vector<std::__cxx11::basic_string<char> >, bool, const char*)’:
/root/vermont-git/src/modules/ipfix/database/IpfixDbWriterSQL.cpp:828:16: error: ‘enterpriseId’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   c.enterprise = enterpriseId;
   ~~~~~~~~~~~~~^~~~~~~~~~~~~~
/root/vermont-git/src/modules/ipfix/database/IpfixDbWriterSQL.cpp:827:13: error: ‘ipfixId’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   c.ipfixId = ipfixId;
   ~~~~~~~~~~^~~~~~~~~
[ 91%] Building CXX object src/modules/CMakeFiles/modules.dir/ipfix/database/IpfixDbReaderOracle.cpp.o
[ 91%] Building CXX object src/modules/CMakeFiles/modules.dir/ipfix/database/IpfixFlowInspectorExporterCfg.cpp.o
[ 92%] Building CXX object src/modules/CMakeFiles/modules.dir/ipfix/database/IpfixFlowInspectorExporter.cpp.o
cc1plus: all warnings being treated as errors
make[2]: *** [src/modules/CMakeFiles/modules.dir/build.make:1402: src/modules/CMakeFiles/modules.dir/ipfix/database/IpfixDbWriterSQL.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:463: src/modules/CMakeFiles/modules.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```