### PR TITLE
Bugfix: Wrong values for flowRate in ipfixSampler lead to crashes

### DIFF
--- a/src/modules/ipfix/IpfixSamplerCfg.cpp
+++ b/src/modules/ipfix/IpfixSamplerCfg.cpp
@@ -42,6 +42,9 @@ IpfixSamplerCfg::IpfixSamplerCfg(XMLElement* elem)
 
 		if (e->matches("flowrate")) {
 			flowRate = getDouble("flowrate");
+			if (flowRate <= 0 || flowRate > 1){
+				THROWEXCEPTION("Illegal value for flowRate. Must be greater 0 and smaller or equal to 1, received %lf", flowRate);
+			}
 		} else if (e->matches("next")) { // ignore next
 		} else {
 			msg(LOG_CRIT, "Unknown IpfixSampler config statement %s\n", e->getName().c_str());


### PR DESCRIPTION
Too small or low values in the configuration of ipfixSampler can
lead to floating point exceptions during runtime.