### PR TITLE
Bugfix: Initialize transoctected in IpfixPrinter

### DIFF
--- a/src/modules/ipfix/Connection.cpp
+++ b/src/modules/ipfix/Connection.cpp
@@ -37,6 +37,7 @@
  */
 Connection::Connection(IpfixDataRecord* record)
 	: srcOctets(0), dstOctets(0),
+	  srcTransOctets(0), dstTransOctets(0),
 	  srcPackets(0), dstPackets(0),
 	  srcTcpControlBits(0), dstTcpControlBits(0),
 	  srcPayload(0), srcPayloadLen(0),


### PR DESCRIPTION
Uninitialized values for srcTransOctets and dstTransOctets lead to
incorrectly printed values in table output of IpfixPrinter if no
transport octets are delivered in the flow