### PR TITLE
Updated AggregatorBaseCfg.cpp to replace call to MSG_ERROR

### DIFF
--- a/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
+++ b/src/modules/ipfix/aggregator/AggregatorBaseCfg.cpp
@@ -210,7 +210,7 @@ Rule::Field* AggregatorBaseCfg::readFlowKeyRule(XMLElement* e) {
 			case IPFIX_TYPEID_sourceMacAddress:
 			case IPFIX_TYPEID_destinationMacAddress:
 				if (parseMacAddressPattern(tmp, &ruleField->pattern, &ruleField->type.length) !=0) {
-					msg(MSG_ERROR, "Bad Mac Address pattern \"%s\"", tmp);
+					msg(LOG_ERR, "Bad Mac Address pattern \"%s\"", tmp);
 					delete [] tmp;
 					throw std::exception();
 				}


### PR DESCRIPTION
Compilation fails on master branch as AggregatorBaseCfg.cpp:213 uses MSG_ERROR, which has been renamed LOG_ERR as per ca85395.